### PR TITLE
Path of the "cbd" binary put in the configuration file

### DIFF
--- a/watchdog/inc/com/centreon/broker/watchdog/configuration_parser.hh
+++ b/watchdog/inc/com/centreon/broker/watchdog/configuration_parser.hh
@@ -52,10 +52,11 @@ namespace         watchdog {
 
     void          _parse_file(std::string const& config_filename);
     void          _parse_xml_document();
-    void          _parse_centreon_broker_element(QDomElement const& element);
+    void          _parse_centreon_broker_element(QDomElement const& element,QString const& bin_path);
 
     QDomDocument  _xml_document;
     QString       _log_path;
+    QString       _bin_path;
     configuration::instance_map
                   _instances_configuration;
 

--- a/watchdog/inc/com/centreon/broker/watchdog/instance_configuration.hh
+++ b/watchdog/inc/com/centreon/broker/watchdog/instance_configuration.hh
@@ -32,7 +32,8 @@ namespace         watchdog {
   class           instance_configuration {
   public:
                   instance_configuration();
-                  instance_configuration(std::string const& name,
+                  instance_configuration(std::string const& bin_path,
+                    std::string const& name,
                     std::string const& config_file,
                     bool should_run,
                     bool should_reload,
@@ -48,6 +49,8 @@ namespace         watchdog {
     bool          is_empty() const throw();
 
     std::string const&
+                  get_bin_path() const throw();
+    std::string const&
                   get_name() const throw();
     std::string const&
                   get_config_file() const throw();
@@ -56,6 +59,7 @@ namespace         watchdog {
     unsigned int  seconds_per_tentative() const throw();
 
   private:
+    std::string   _bin_path;
     std::string   _name;
     std::string   _config_file;
     bool          _run;

--- a/watchdog/src/configuration_parser.cc
+++ b/watchdog/src/configuration_parser.cc
@@ -83,8 +83,10 @@ void configuration_parser::_parse_xml_document() {
   while(!e.isNull()) {
       if (e.tagName() == "log")
         _log_path = e.text();
-      else if (e.tagName() == "cbd")
-        _parse_centreon_broker_element(e);
+      else if (e.tagName() == "bin")
+        _bin_path = e.text();
+      else if (e.tagName() == "cbd" && _bin_path != "")
+        _parse_centreon_broker_element(e, _bin_path);
      e = e.nextSiblingElement();
   }
 }
@@ -95,7 +97,7 @@ void configuration_parser::_parse_xml_document() {
  *  @param[in] element  The element.
  */
 void configuration_parser::_parse_centreon_broker_element(
-                             QDomElement const& element) {
+                             QDomElement const& element, QString const& bin_path) {
   // The default are sane.
   QString instance_name = element.firstChildElement("name").text();
   QString instance_config = element.firstChildElement("configuration_file").text();
@@ -111,6 +113,7 @@ void configuration_parser::_parse_centreon_broker_element(
     std::make_pair(
            instance_name.toStdString(),
            instance_configuration(
+             bin_path.toStdString(),
              instance_name.toStdString(),
              instance_config.toStdString(),
              run,

--- a/watchdog/src/instance.cc
+++ b/watchdog/src/instance.cc
@@ -74,7 +74,7 @@ void instance::start_instance() {
     logging::info(logging::medium)
       << "watchdog: starting process '" << _config.get_name() << "'";
     start(
-      "/usr/sbin/cbd",
+      QString::fromStdString(_config.get_bin_path()),
        QStringList(QString::fromStdString(_config.get_config_file())),
        QProcess::ReadOnly);
   }

--- a/watchdog/src/instance_configuration.cc
+++ b/watchdog/src/instance_configuration.cc
@@ -30,6 +30,7 @@ instance_configuration::instance_configuration()
 /**
  *  Constructor.
  *
+ *  @param[in] bin_path       The bin path of the instance.
  *  @param[in] name           The name of the instance.
  *  @param[in] config_file    The config file of the instance.
  *  @param[in] should_run     Should this instance be run?
@@ -37,12 +38,14 @@ instance_configuration::instance_configuration()
  *  @param[in] seconds_per_tentative  The number of seconds between tentatives.
  */
 instance_configuration::instance_configuration(
+                                 std::string const& bin_path,
                                  std::string const& name,
                                  std::string const& config_file,
                                  bool should_run,
                                  bool should_reload,
                                  unsigned int seconds_per_tentative)
-  : _name(name),
+  : _bin_path(bin_path),
+    _name(name),
     _config_file(config_file),
     _run(should_run),
     _reload(should_reload),
@@ -59,7 +62,8 @@ instance_configuration::~instance_configuration() {}
  */
 instance_configuration::instance_configuration(
                                  instance_configuration const& other)
-  : _name(other._name),
+  : _bin_path(other._bin_path),
+    _name(other._name),
     _config_file(other._config_file),
     _run(other._run),
     _reload(other._reload),
@@ -75,6 +79,7 @@ instance_configuration::instance_configuration(
 instance_configuration& instance_configuration::operator=(
                                  instance_configuration const& other) {
   if (this != &other) {
+    _bin_path = other._bin_path;
     _name = other._name;
     _config_file = other._config_file;
     _run = other._run;
@@ -96,7 +101,8 @@ instance_configuration& instance_configuration::operator=(
  */
 bool instance_configuration::operator==(
        instance_configuration const& other) const {
-  return (_name == other._name
+  return (_bin_path == other._bin_path
+          && _name == other._name
           && _config_file == other._config_file
           && _run == other._run);
 }
@@ -111,6 +117,16 @@ bool instance_configuration::operator==(
 bool instance_configuration::operator!=(
        instance_configuration const& other) const {
   return (!instance_configuration::operator==(other));
+}
+
+/**
+ *  Get the bin path for this instance.
+ *
+ *  @return[in]  The bin path for this instance.
+ */
+std::string const&
+  instance_configuration::get_bin_path() const throw() {
+  return (_bin_path);
 }
 
 /**


### PR DESCRIPTION
Je propose ces modifications par rapport à un besoin, car notre installation n'utilisant pas les chemins par défaut de centreon, cbdw ne fonctionnait pas.
Le problème que je vois à ces changements est : Mettre les balises `<bin></bin>` en haut du fichier XML pour que ça fonctionne correctement.

je n'ai pas pu changer le fichier "watchdog.xml.in", problème d'autorisation proxy.

------

```
<centreonbroker>
  <!--
  This file configures the watchdog used to launch and watch over
  Centreon Broker's instances.
  All instances are written in this form:
  <cbd>
    <name>Name of the instance</name> (must be unique)
    <configuration_file>configuration file of the instance</configuration_file>
    <run>0/1</run> (1 for starting the instance, 0 to not launch anything)
    <reload>0/1</reload> (1 to allow reloading)
    <seconds_per_tentative>number</seconds_per_tentative> (how many seconds between each startup)
  </cbd>
  <name> and <configuration_file> are mandatory.
  -->
  <bin>/usr/sbin/cbd</bin>
@DAEMONS_CONFIGURATION@
  <log>/var/log/centreon-broker/watchdog.log</log>
</centreonbroker>
```