### PR TITLE
influxdb: fix for influxdb 1.x

### DIFF
--- a/influxdb/src/influxdb10.cc
+++ b/influxdb/src/influxdb10.cc
@@ -285,7 +285,7 @@ void influxdb10::_create_queries(
     }
   if (!first)
     query_str.append(" ");
-  query_str.append("$TIME$\n");
+  query_str.append("$TIME$000000000\n");
   _status_query = query(query_str, query::status, _cache, true);
 
    // Create metric query.
@@ -337,6 +337,6 @@ void influxdb10::_create_queries(
      }
    if (!first)
      query_str.append(" ");
-    query_str.append("$TIME$\n");
+    query_str.append("$TIME$000000000\n");
     _metric_query = query(query_str, query::metric, _cache, true);
 }

--- a/influxdb/src/influxdb10.cc
+++ b/influxdb/src/influxdb10.cc
@@ -189,7 +189,7 @@ bool influxdb10::_check_answer_string(std::string const& ans) {
       << "' and port '" << _socket->peerPort() << "': got '"
       << first_line_str << "'");
 
-  if (split[0] == "HTTP/1.0" && split[1] == "200" && split[2] == "OK")
+  if (split[0] == "HTTP/1.0" && split[1] == "204" && split[2] == "No" && split[3] == "Content")
     return (true);
   else
     throw (exceptions::msg()
@@ -246,18 +246,10 @@ void influxdb10::_create_queries(
        it != end; ++it)
     if (it->is_flag()) {
       query_str.append(",");
-      if (it->get_type() == column::number)
-        query_str
-          .append(escape(it->get_name()))
-          .append("=")
-          .append(escape(it->get_value()));
-      else if (it->get_type() == column::string)
-        query_str
-          .append(escape(it->get_name()))
-          .append("=")
-          .append("\"")
-          .append(escape(it->get_value()))
-          .append("\"");
+      query_str
+        .append(escape(it->get_name()))
+        .append("=")
+        .append(escape(it->get_value()));
     }
   query_str.append(" ");
   bool first = true;
@@ -298,18 +290,10 @@ void influxdb10::_create_queries(
         it != end; ++it)
      if (it->is_flag()) {
        query_str.append(",");
-       if (it->get_type() == column::number)
-         query_str
-           .append(escape(it->get_name()))
-           .append("=")
-           .append(escape(it->get_value()));
-       else if (it->get_type() == column::string)
-         query_str
-           .append(escape(it->get_name()))
-           .append("=")
-           .append("\"")
-           .append(escape(it->get_value()))
-           .append("\"");
+       query_str
+         .append(escape(it->get_name()))
+         .append("=")
+         .append(escape(it->get_value()));
      }
    query_str.append(" ");
    first = true;


### PR DESCRIPTION
Since influxdb 1.0 the timestamp uses a int64 https://docs.influxdata.com/influxdb/v1.0/write_protocols/line_protocol_tutorial/#timestamp
https://docs.influxdata.com/influxdb/v1.2/write_protocols/line_protocol_reference/#data-types

Status code 204 => OK => https://docs.influxdata.com/influxdb/v1.2/tools/api/#status-codes-and-responses-2

Double quote string field values, Never for measurements, tag keys, tag values, field keys => https://docs.influxdata.com/influxdb/v1.2/write_protocols/line_protocol_reference/#quoting

Build OK : 
[root@localhost build]# make
[ 27%] Built target rokerbase
[ 27%] Built target roker
[ 27%] Built target cbd
[ 29%] Built target cbwd
[ 31%] Built target 15-stats
[ 38%] Built target nebbase
[ 41%] Built target 10-neb
[ 51%] Built target cbmod
[ 63%] Built target 40-notification
[ 65%] Built target 30-correlation
[ 70%] Built target 05-dumper
[ 73%] Built target 70-rrd
[ 74%] Built target 80-sql
[ 77%] Built target 20-storage
Scanning dependencies of target 70-influxdb
[ 78%] Building CXX object influxdb/CMakeFiles/70-influxdb.dir/root/centreon-broker/influxdb/src/influxdb10.cc.o
Linking CXX shared library 70-influxdb.so
[ 79%] Built target 70-influxdb
[ 80%] Built target 70-graphite
[ 97%] Built target 20-bam
[ 98%] Built target 50-tcp
[100%] Built target 60-tls
[root@localhost build]#

