### PR TITLE
Fixes error in rebuilding metrics

### DIFF
--- a/storage/src/rebuilder.cc
+++ b/storage/src/rebuilder.cc
@@ -226,9 +226,9 @@ void rebuilder::run() {
             metrics_to_rebuild.pop_front();
             _rebuild_metric(
               *db,
+              info.metric_id,
               host_id,
               service_id,
-              info.metric_id,
               info.metric_name,
               info.metric_type,
               check_interval,


### PR DESCRIPTION
There is a mismatch in the passed paramters to _rebuild_metric() that causes metrics to not be properly rebuilt, or rebuilt with wrong data!
See the definition of _revuild_metric().
The problem surfaced from this forum post:
https://forum.centreon.com/forum/centreon-collect/centreon-broker/143995-unable-to-rebuild-rrd

Please accept as bugfix; it fixes the issue.