### PR TITLE
feat(storage): allow cancellation of graph rebuild

### DIFF
--- a/doc/release_notes/broker30.rst
+++ b/doc/release_notes/broker30.rst
@@ -6,6 +6,20 @@ Centreon Broker 3.0.10
 Bug fixes
 *********
 
+************
+Enhancements
+************
+
+Graph rebuild cancellation
+==========================
+
+In previous versions, Centreon Broker kept a cache of all hosts and
+services needed to be rebuilt. However such operations are slow and in
+some cases operators might want to cancel ongoing rebuild. In this
+version each host and service is treated individually. Therefore upon
+cancellation rebuild will stop after the current host or service has
+been rebuilt.
+
 =====================
 Centreon Broker 3.0.9
 =====================

--- a/storage/inc/com/centreon/broker/storage/rebuilder.hh
+++ b/storage/inc/com/centreon/broker/storage/rebuilder.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2012-2015 Centreon
+** Copyright 2012-2015,2017 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ namespace           storage {
    *  Check for graphs to be rebuild at fixed interval.
    */
   class             rebuilder : public QThread {
-  public:
+   public:
                     rebuilder(
                       database_config const& db_cfg,
                       unsigned int rebuild_check_interval = 600,
@@ -48,9 +48,26 @@ namespace           storage {
     unsigned int    get_rrd_length() const throw ();
     void            run();
 
-  private:
+   private:
+    // Local types.
+    struct index_info {
+      unsigned int index_id;
+      unsigned int host_id;
+      unsigned int service_id;
+      unsigned int rrd_retention;
+    };
+
+    struct metric_info {
+      unsigned int metric_id;
+      QString metric_name;
+      short metric_type;
+    };
+
                     rebuilder(rebuilder const& other);
     rebuilder&      operator=(rebuilder const& other);
+    void            _next_index_to_rebuild(
+                      index_info& info,
+                      database& db);
     void            _rebuild_metric(
                       database& db,
                       unsigned int metric_id,


### PR DESCRIPTION
Indexes (host or service) are now processed one by one. This allows
cancellation of massive graph rebuilt after the current index has
been processed.