### PR TITLE
fix(storage): mark graphs as being rebuild.

### DIFF
--- a/doc/release_notes/broker30.rst
+++ b/doc/release_notes/broker30.rst
@@ -20,6 +20,12 @@ version each host and service is treated individually. Therefore upon
 cancellation rebuild will stop after the current host or service has
 been rebuilt.
 
+Flag graphs when rebuilding
+===========================
+
+Flag graphs as rebuilding upon processing. This was caused by
+uncommitted SQL transactions.
+
 Properly process downtimes sent simultaneously on same host/service
 ===================================================================
 

--- a/storage/src/rebuilder.cc
+++ b/storage/src/rebuilder.cc
@@ -57,7 +57,9 @@ rebuilder::rebuilder(
   : _db_cfg(db_cfg),
     _interval(rebuild_check_interval),
     _rrd_len(rrd_length),
-    _should_exit(false) {}
+    _should_exit(false) {
+  _db_cfg.set_queries_per_transaction(1);
+}
 
 /**
  *  Destructor.


### PR DESCRIPTION
The /must_be_rebuild/ flag of the /index_data/ table was properly
updated to 2 but within an uncommitted transaction. This prevented
users from getting the current rebuilding status.