### PR TITLE
feat(muxer): Old queue files are not used by maps.

### DIFF
--- a/core/inc/com/centreon/broker/file/cfile.hh
+++ b/core/inc/com/centreon/broker/file/cfile.hh
@@ -36,6 +36,7 @@ namespace  file {
    public:
            cfile(std::string const& path, fs_file::open_mode mode);
            ~cfile();
+    void   close();
     long   read(void* buffer, long max_size);
     void   seek(
              long offset,
@@ -46,8 +47,13 @@ namespace  file {
    private:
            cfile(cfile const& right);
     cfile& operator=(cfile const& right);
+    void   _open();
 
     FILE*  _stream;
+    std::string
+           _path;
+    open_mode
+           _mode;
   };
 
   /**

--- a/core/inc/com/centreon/broker/file/fs_file.hh
+++ b/core/inc/com/centreon/broker/file/fs_file.hh
@@ -47,6 +47,7 @@ namespace        file {
 
                  fs_file();
     virtual      ~fs_file();
+    virtual void close() = 0;
     virtual long read(void* buffer, long max_size) = 0;
     virtual void seek(
                    long offset,

--- a/core/inc/com/centreon/broker/file/splitter.hh
+++ b/core/inc/com/centreon/broker/file/splitter.hh
@@ -46,7 +46,9 @@ namespace       file {
                   long max_file_size = 100000000,
                   bool auto_delete = false);
                 ~splitter();
+    void        close();
     long        read(void* buffer, long max_size);
+    void        remove_all_files();
     void        seek(
                   long offset,
                   fs_file::seek_whence whence = fs_file::seek_start);

--- a/core/inc/com/centreon/broker/file/stream.hh
+++ b/core/inc/com/centreon/broker/file/stream.hh
@@ -42,6 +42,7 @@ namespace              file {
     bool               read(
                          misc::shared_ptr<io::data>& d,
                          time_t deadline);
+    void               remove_all_files();
     void               statistics(io::properties& tree) const;
     int                write(misc::shared_ptr<io::data> const& d);
 

--- a/core/inc/com/centreon/broker/multiplexing/muxer.hh
+++ b/core/inc/com/centreon/broker/multiplexing/muxer.hh
@@ -23,7 +23,7 @@
 #  include <queue>
 #  include <QWaitCondition>
 #  include <string>
-#  include "com/centreon/broker/io/stream.hh"
+#  include "com/centreon/broker/persistent_file.hh"
 #  include "com/centreon/broker/misc/unordered_hash.hh"
 #  include "com/centreon/broker/namespace.hh"
 
@@ -63,6 +63,7 @@ namespace               multiplexing {
     filters const&      get_write_filters() const;
     unsigned int        get_event_queue_size() const;
     void                nack_events();
+    void                remove_queue_files();
     void                statistics(io::properties& tree) const;
     void                wake();
     int                 write(misc::shared_ptr<io::data> const& d);
@@ -86,7 +87,7 @@ namespace               multiplexing {
                         _events;
     unsigned int        _events_size;
     static unsigned int _event_queue_max_size;
-    std::auto_ptr<io::stream>
+    std::auto_ptr<persistent_file>
                         _file;
     mutable QMutex      _mutex;
     std::string         _name;

--- a/core/inc/com/centreon/broker/persistent_file.hh
+++ b/core/inc/com/centreon/broker/persistent_file.hh
@@ -19,6 +19,7 @@
 #ifndef CCB_PERSISTENT_FILE_HH
 #  define CCB_PERSISTENT_FILE_HH
 
+#  include "com/centreon/broker/file/stream.hh"
 #  include "com/centreon/broker/io/stream.hh"
 #  include "com/centreon/broker/namespace.hh"
 
@@ -37,13 +38,17 @@ class              persistent_file : public io::stream {
                    ~persistent_file();
   bool             read(
                      misc::shared_ptr<io::data>& d,
-                     time_t deadline);
+                     time_t deadline = (time_t)-1);
+  void             remove_all_files();
   void             statistics(io::properties& tree) const;
   int              write(misc::shared_ptr<io::data> const& d);
 
  private:
                    persistent_file(persistent_file const& other);
   persistent_file& operator=(persistent_file const& other);
+
+  misc::shared_ptr<file::stream>
+                   _splitter;
 };
 
 CCB_END()

--- a/core/src/file/splitter.cc
+++ b/core/src/file/splitter.cc
@@ -128,6 +128,21 @@ splitter::splitter(
 splitter::~splitter() {}
 
 /**
+ *  Close files open by splitter.
+ *  If no files are open, nothing is done.
+ */
+void splitter::close() {
+  if (!_rfile.isNull()) {
+    _rfile->close();
+    _rfile.clear();
+  }
+  if (!_wfile.isNull()) {
+    _wfile->close();
+    _wfile.clear();
+  }
+}
+
+/**
  *  Read data.
  *
  *  @param[out] buffer    Output buffer.
@@ -300,6 +315,36 @@ int splitter::get_wid() const {
  */
 long splitter::get_woffset() const {
   return (_woffset);
+}
+
+/**
+ *  Remove all the files the splitter is concerned by.
+ */
+void splitter::remove_all_files() {
+  close();
+  std::string base_dir;
+  std::string base_name;
+  {
+    size_t last_slash(_base_path.find_last_of('/'));
+    if (last_slash == std::string::npos) {
+      base_dir = "./";
+      base_name = _base_path;
+    }
+    else {
+      base_dir = _base_path.substr(0, last_slash + 1).c_str();
+      base_name = _base_path.substr(last_slash + 1).c_str();
+    }
+  }
+  fs_browser::entry_list parts;
+  {
+    std::string name_pattern(base_name);
+    name_pattern.append("*");
+    parts = _fs->read_directory(base_dir, name_pattern);
+  }
+  for (fs_browser::entry_list::iterator it(parts.begin()), end(parts.end());
+       it != end;
+       ++it)
+    _fs->remove(base_dir + '/' + *it);
 }
 
 /**

--- a/core/src/file/stream.cc
+++ b/core/src/file/stream.cc
@@ -233,3 +233,10 @@ int stream::write(misc::shared_ptr<io::data> const& d) {
 
   return (1);
 }
+
+/**
+ *  Remove all the files this stream in concerned by.
+ */
+void stream::remove_all_files() {
+  _file->remove_all_files();
+}

--- a/core/src/multiplexing/muxer.cc
+++ b/core/src/multiplexing/muxer.cc
@@ -16,6 +16,7 @@
 ** For more information : contact@centreon.com
 */
 
+#include <QDir>
 #include <limits>
 #include <memory>
 #include <sstream>
@@ -478,4 +479,16 @@ void muxer::_push_to_queue(misc::shared_ptr<io::data> const& event) {
  */
 std::string muxer::_queue_file() const {
   return (queue_file(_name));
+}
+
+/**
+ *  Remove all the queue files attached to this muxer.
+ */
+void muxer::remove_queue_files() {
+  logging::info(logging::low)
+    << "multiplexing: '" << _queue_file() << "' removed";
+
+  /* Here _file is already destroyed */
+  persistent_file file(_queue_file());
+  file.remove_all_files();
 }

--- a/core/src/persistent_file.cc
+++ b/core/src/persistent_file.cc
@@ -21,6 +21,7 @@
 #include "com/centreon/broker/file/opener.hh"
 #include "com/centreon/broker/misc/shared_ptr.hh"
 #include "com/centreon/broker/persistent_file.hh"
+#include "com/centreon/broker/file/stream.hh"
 
 using namespace com::centreon::broker;
 
@@ -34,6 +35,7 @@ persistent_file::persistent_file(std::string const& path) {
   file::opener opnr;
   opnr.set_filename(path);
   misc::shared_ptr<io::stream> fs(opnr.open());
+  _splitter = fs.staticCast<file::stream>();
 
   // Compression layer.
   misc::shared_ptr<compression::stream> cs(new compression::stream);
@@ -85,4 +87,11 @@ void persistent_file::statistics(io::properties& tree) const {
  */
 int persistent_file::write(misc::shared_ptr<io::data> const& d) {
   return (_substream->write(d));
+}
+
+/**
+ *  Remove persistent file.
+ */
+void persistent_file::remove_all_files() {
+  _splitter->remove_all_files();
 }

--- a/core/src/processing/feeder.cc
+++ b/core/src/processing/feeder.cc
@@ -139,6 +139,7 @@ void feeder::run() {
   {
     QWriteLocker lock(&_client_mutex);
     _client.clear();
+    _subscriber.get_muxer().remove_queue_files();
   }
   logging::info(logging::medium)
     << "feeder: thread of client '" << _name << "' will exit";

--- a/core/test/file/test_file.cc
+++ b/core/test/file/test_file.cc
@@ -28,6 +28,8 @@ test_file::test_file(std::string* content)
 
 test_file::~test_file() {}
 
+void test_file::close() {}
+
 long test_file::read(void* buffer, long max_size) {
   long size(_content->size() - _pos);
   if (!size)

--- a/core/test/file/test_file.hh
+++ b/core/test/file/test_file.hh
@@ -27,6 +27,7 @@ class          test_file : public com::centreon::broker::file::fs_file {
  public:
                test_file(std::string* content);
                ~test_file();
+  void         close();
   long         read(void* buffer, long max_size);
   void         seek(
                  long offset,


### PR DESCRIPTION
Instead of keeping them, we delete them. This is done from subscriber class
because we have the same behavior for all subscribers than for maps.