### PR TITLE
feat(graphite): escape dots.

### DIFF
--- a/graphite/inc/com/centreon/broker/graphite/connector.hh
+++ b/graphite/inc/com/centreon/broker/graphite/connector.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2013 Centreon
+** Copyright 2011-2013,2017 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -33,13 +33,15 @@ namespace           graphite {
    *  @brief Connect to a graphite stream.
    */
   class             connector : public io::endpoint {
-  public:
+   public:
                     connector();
                     connector(connector const& other);
                     ~connector();
     connector&      operator=(connector const& other);
-    void            connect_to(std::string const& metric_naming,
+    void            connect_to(
+                      std::string const& metric_naming,
                       std::string const& status_naming,
+                      std::string const& escape_string,
                       std::string const& db_user,
                       std::string const& db_passwd,
                       std::string const& db_host,
@@ -50,6 +52,7 @@ namespace           graphite {
                     open();
 
    private:
+    std::string     _escape_string;
     std::string     _metric_naming;
     std::string     _status_naming;
     std::string     _user;

--- a/graphite/inc/com/centreon/broker/graphite/query.hh
+++ b/graphite/inc/com/centreon/broker/graphite/query.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2015 Centreon
+** Copyright 2015,2017 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -40,21 +40,25 @@ namespace         graphite {
    *  the query fast.
    */
   class           query {
-  public:
+   public:
     enum          data_type {
                   metric,
                   status
     };
 
-                  query(std::string const& naming_scheme, data_type type, macro_cache const& cache);
-                  query(query const& f);
+                  query(
+                    std::string const& naming_scheme,
+                    std::string const& escape_string,
+                    data_type type,
+                    macro_cache const& cache);
+                  query(query const& other);
                   ~query();
-    query&        operator=(query const& f);
+    query&        operator=(query const& other);
 
     std::string   generate_metric(storage::metric const& me);
     std::string   generate_status(storage::status const& st);
 
-  private:
+   private:
     // Compiled data.
     std::vector<std::string>
                   _compiled_naming_scheme;
@@ -62,6 +66,7 @@ namespace         graphite {
                   _compiled_getters;
 
     // Used for generation.
+    std::string   _escape_string;
     size_t        _naming_scheme_index;
     data_type     _type;
 
@@ -72,10 +77,13 @@ namespace         graphite {
     void          _compile_naming_scheme(
                     std::string const& naming_scheme,
                     data_type type);
+    QString       _escape(QString const& str);
     void          _throw_on_invalid(data_type macro_type);
 
     template <typename T, typename U, T (U::*member)>
     void          _get_member(io::data const& d, std::ostream& is);
+    template <typename U, QString (U::*member)>
+    void          _get_string_member(io::data const& d, std::ostream& is);
     void          _get_string(io::data const& d, std::ostream& is);
     void          _get_null(io::data const& d, std::ostream& is);
     void          _get_dollar_sign(io::data const& d, std::ostream& is);

--- a/graphite/inc/com/centreon/broker/graphite/stream.hh
+++ b/graphite/inc/com/centreon/broker/graphite/stream.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2015 Centreon
+** Copyright 2015-2017 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ namespace          graphite {
                    stream(
                      std::string const& metric_naming,
                      std::string const& status_naming,
+                     std::string const& escape_string,
                      std::string const& db_user,
                      std::string const& db_password,
                      std::string const& db_host,

--- a/graphite/src/connector.cc
+++ b/graphite/src/connector.cc
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2015 Centreon
+** Copyright 2015,2017 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -71,12 +71,14 @@ connector& connector::operator=(connector const& other) {
 void connector::connect_to(
                   std::string const& metric_naming,
                   std::string const& status_naming,
+                  std::string const& escape_string,
                   std::string const& db_user,
                   std::string const& db_passwd,
                   std::string const& db_addr,
                   unsigned short db_port,
                   unsigned int queries_per_transaction,
                   misc::shared_ptr<persistent_cache> const& cache) {
+  _escape_string = escape_string;
   _metric_naming = metric_naming;
   _status_naming = status_naming;
   _user = db_user;
@@ -98,6 +100,7 @@ misc::shared_ptr<io::stream> connector::open() {
             new stream(
                   _metric_naming,
                   _status_naming,
+                  _escape_string,
                   _user,
                   _password,
                   _addr,
@@ -118,6 +121,7 @@ misc::shared_ptr<io::stream> connector::open() {
  *  @param[in] other  Object to copy.
  */
 void connector::_internal_copy(connector const& other) {
+  _escape_string = other._escape_string;
   _metric_naming = other._metric_naming;
   _status_naming = other._status_naming;
   _user = other._user;

--- a/graphite/src/factory.cc
+++ b/graphite/src/factory.cc
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2016 Centreon
+** Copyright 2011-2017 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -164,25 +164,27 @@ io::endpoint* factory::new_endpoint(
                          bool& is_acceptor,
                          misc::shared_ptr<persistent_cache> cache) const {
   std::string db_host(find_param(cfg, "db_host"));
-
-  std::string metric_naming(
-        get_string_param(cfg, "metric_naming", "centreon.metrics.$METRICID$"));
-  std::string status_naming(
-        get_string_param(cfg, "status_naming", "centreon.statuses.$INDEXID$"));
   unsigned short db_port(
-        get_uint_param(cfg, "db_port", 80));
+    get_uint_param(cfg, "db_port", 2003));
   std::string db_user(
-        get_string_param(cfg, "db_user", ""));
+    get_string_param(cfg, "db_user", ""));
   std::string db_password(
-        get_string_param(cfg, "db_password", ""));
+    get_string_param(cfg, "db_password", ""));
   unsigned int queries_per_transaction(
-                 get_uint_param(cfg, "queries_per_transaction", 1));
+    get_uint_param(cfg, "queries_per_transaction", 1));
+  std::string metric_naming(
+    get_string_param(cfg, "metric_naming", "centreon.metrics.$METRICID$"));
+  std::string status_naming(
+    get_string_param(cfg, "status_naming", "centreon.statuses.$INDEXID$"));
+  std::string escape_string(
+    get_string_param(cfg, "escape_string", "_"));
 
   // Connector.
   std::auto_ptr<graphite::connector> c(new graphite::connector);
   c->connect_to(
        metric_naming,
        status_naming,
+       escape_string,
        db_user,
        db_password,
        db_host,

--- a/graphite/src/stream.cc
+++ b/graphite/src/stream.cc
@@ -47,6 +47,7 @@ using namespace com::centreon::broker::graphite;
 stream::stream(
           std::string const& metric_naming,
           std::string const& status_naming,
+          std::string const& escape_string,
           std::string const& db_user,
           std::string const& db_password,
           std::string const& db_host,
@@ -59,14 +60,24 @@ stream::stream(
     _db_password(db_password),
     _db_host(db_host),
     _db_port(db_port),
-    _queries_per_transaction(queries_per_transaction == 0 ?
-                               1 : queries_per_transaction),
+    _queries_per_transaction(
+      (queries_per_transaction == 0)
+      ? 1
+      : queries_per_transaction),
     _pending_queries(0),
     _actual_query(0),
     _commit_flag(false),
     _cache(cache),
-    _metric_query(_metric_naming, query::metric, _cache),
-    _status_query(_status_naming, query::status, _cache) {
+    _metric_query(
+      _metric_naming,
+      escape_string,
+      query::metric,
+      _cache),
+    _status_query(
+      _status_naming,
+      escape_string,
+      query::status,
+      _cache) {
   // Create the basic HTTP authentification header.
   if (!_db_user.empty() && !_db_password.empty()) {
     QByteArray auth;


### PR DESCRIPTION
Endpoints with the /graphite/ type now have a /escape_string/
configuration parameter. It is used to replace dots (.) in service
description, host names, metric names, ... to avoid unwanted
hierarchical ordering in Graphite. By default this parameter is
set to underscore (_). That is dots are replaced by underscores.