### PR TITLE
fix(bam): Bad boolexp computation

### DIFF
--- a/bam/inc/com/centreon/broker/bam/configuration/applier/kpi.hh
+++ b/bam/inc/com/centreon/broker/bam/configuration/applier/kpi.hh
@@ -70,7 +70,11 @@ namespace     bam {
         void  _internal_copy(kpi const& other);
         misc::shared_ptr<bam::kpi>
               _new_kpi(configuration::kpi const& cfg);
+        void  _invalidate_ba(configuration::kpi const& cfg);
         void  _remove_kpi(unsigned int kpi_id);
+        void  _resolve_kpi(
+                configuration::kpi const& cfg,
+                misc::shared_ptr<bam::kpi>);
 
         std::map<unsigned int, applied>
               _applied;

--- a/bam/src/kpi_event.cc
+++ b/bam/src/kpi_event.cc
@@ -16,8 +16,8 @@
 ** For more information : contact@centreon.com
 */
 
-#include "com/centreon/broker/bam/kpi_event.hh"
 #include "com/centreon/broker/bam/internal.hh"
+#include "com/centreon/broker/bam/kpi_event.hh"
 #include "com/centreon/broker/io/events.hh"
 
 using namespace com::centreon::broker;


### PR DESCRIPTION
When the kpi configuration applier applies the configuration, the
connection betwwen kpis and targets may be cut. Now, a new step
is done consisting in checking and reestablishing connections.

This patch should fix issue #145 
