### PR TITLE
Lua cache improvement

### DIFF
--- a/bam/src/dimension_kpi_event.cc
+++ b/bam/src/dimension_kpi_event.cc
@@ -103,6 +103,15 @@ bool dimension_kpi_event::operator==(
  *  @return Event type.
  */
 unsigned int dimension_kpi_event::type() const {
+  return (dimension_kpi_event::static_type());
+}
+
+/**
+ *  Get the event type.
+ *
+ *  @return Event type.
+ */
+unsigned int dimension_kpi_event::static_type() {
   return (io::events::data_type<io::events::bam, bam::de_dimension_kpi_event>::value);
 }
 

--- a/doc/exploit/stream_connectors.rst
+++ b/doc/exploit/stream_connectors.rst
@@ -203,6 +203,17 @@ The available methods are:
 5. ``get_service_description(host_id,service_id)`` that gets from the cache the
    service description of the given pair host_id / service_id. This function
    returns a string or *nil* otherwise.
+6. ``get_hostgroup_name(id)`` that gets from the cache the host group name of
+   the given id. This function returns a string or *nil* otherwise.
+7. ``get_servicegroup_name(id)`` that gets from the cache the service group name*
+   of the given id. This function returns a string or *nil* otherwise.
+8. ``get_hostgroups(host_id)`` that gets the list of host groups containing the
+   host corresponding to *host_id*. The return value is an array of objects,
+   each one containing two fields, *group_id* and *group_name*.
+9. ``get_servicegroups(host_id, service_id)`` that gets the list of service
+   groups containing the service corresponding to the pair *host_id* /
+   *service_id*. The return value is an array of objects, each one containing
+   two fields, *group_id* and *group_name*.
 
 The init() function
 ===================

--- a/doc/exploit/stream_connectors.rst
+++ b/doc/exploit/stream_connectors.rst
@@ -189,27 +189,27 @@ just return ``nil``.
 
 The available methods are:
 
-1. ``get_hostname(id)`` that gets from the cache the host name corresponding to
-   the given host id. This function returns a string with the host name or
-   *nil* otherwise.
-2. ``get_index_mapping(index_id)`` that gets from the cache the
-   index mapping object of the given index id. The result is a table containing
-   three keys, ``index_id``, ``host_id`` and ``service_id``.
-3. ``get_instance_name(instance_id)`` that gets from the cache the
-   instance name corresponding to the instance id.
-4. ``get_metric_mapping(metric_id)`` that gets from the cache the
-   metric mapping object of the given metric id. The result is a table
-   containing two keys, ``metric_id`` and ``index_id``.
-5. ``get_service_description(host_id,service_id)`` that gets from the cache the
-   service description of the given pair host_id / service_id. This function
-   returns a string or *nil* otherwise.
-6. ``get_hostgroup_name(id)`` that gets from the cache the host group name of
+1. ``get_hostgroup_name(id)`` that gets from the cache the host group name of
    the given id. This function returns a string or *nil* otherwise.
-7. ``get_servicegroup_name(id)`` that gets from the cache the service group name*
-   of the given id. This function returns a string or *nil* otherwise.
-8. ``get_hostgroups(host_id)`` that gets the list of host groups containing the
+2. ``get_hostgroups(host_id)`` that gets the list of host groups containing the
    host corresponding to *host_id*. The return value is an array of objects,
    each one containing two fields, *group_id* and *group_name*.
+3. ``get_hostname(id)`` that gets from the cache the host name corresponding to
+   the given host id. This function returns a string with the host name or
+   *nil* otherwise.
+4. ``get_index_mapping(index_id)`` that gets from the cache the
+   index mapping object of the given index id. The result is a table containing
+   three keys, ``index_id``, ``host_id`` and ``service_id``.
+5. ``get_instance_name(instance_id)`` that gets from the cache the
+   instance name corresponding to the instance id.
+6. ``get_metric_mapping(metric_id)`` that gets from the cache the
+   metric mapping object of the given metric id. The result is a table
+   containing two keys, ``metric_id`` and ``index_id``.
+7. ``get_service_description(host_id,service_id)`` that gets from the cache the
+   service description of the given pair host_id / service_id. This function
+   returns a string or *nil* otherwise.
+8. ``get_servicegroup_name(id)`` that gets from the cache the service group name
+   of the given id. This function returns a string or *nil* otherwise.
 9. ``get_servicegroups(host_id, service_id)`` that gets the list of service
    groups containing the service corresponding to the pair *host_id* /
    *service_id*. The return value is an array of objects, each one containing

--- a/lua/inc/com/centreon/broker/lua/macro_cache.hh
+++ b/lua/inc/com/centreon/broker/lua/macro_cache.hh
@@ -22,6 +22,8 @@
 #  include <QHash>
 #  include "com/centreon/broker/instance_broadcast.hh"
 #  include "com/centreon/broker/neb/host.hh"
+#  include "com/centreon/broker/neb/host_group.hh"
+#  include "com/centreon/broker/neb/host_group_member.hh"
 #  include "com/centreon/broker/neb/instance.hh"
 #  include "com/centreon/broker/neb/service.hh"
 #  include "com/centreon/broker/persistent_cache.hh"
@@ -47,6 +49,9 @@ namespace         lua {
     storage::metric_mapping const&
                    get_metric_mapping(unsigned int metric_id) const;
     QString const& get_host_name(unsigned int host_id) const;
+    QString const& get_host_group_name(unsigned int id) const;
+    QMultiHash<unsigned int, neb::host_group_member> const&
+                   get_host_group_members() const;
     QString const& get_service_description(
                      unsigned int host_id,
                      unsigned int service_id) const;
@@ -58,6 +63,8 @@ namespace         lua {
 
     void           _process_instance(instance_broadcast const& in);
     void           _process_host(neb::host const& h);
+    void           _process_host_group(neb::host_group const& hg);
+    void           _process_host_group_member(neb::host_group_member const& hgm);
     void           _process_service(neb::service const& s);
     void           _process_index_mapping(storage::index_mapping const& im);
     void           _process_metric_mapping(storage::metric_mapping const& mm);
@@ -69,6 +76,10 @@ namespace         lua {
                    _instances;
     QHash<unsigned int, neb::host>
                    _hosts;
+    QHash<unsigned int, neb::host_group>
+                   _host_groups;
+    QMultiHash<unsigned int, neb::host_group_member>
+                   _host_group_members;
     QHash<QPair<unsigned int, unsigned int>, neb::service>
                    _services;
     QHash<unsigned int, storage::index_mapping>

--- a/lua/inc/com/centreon/broker/lua/macro_cache.hh
+++ b/lua/inc/com/centreon/broker/lua/macro_cache.hh
@@ -52,13 +52,14 @@ namespace         lua {
                    get_metric_mapping(unsigned int metric_id) const;
     QString const& get_host_name(unsigned int host_id) const;
     QString const& get_host_group_name(unsigned int id) const;
-    QMultiHash<unsigned int, neb::host_group_member> const&
+    QHash<unsigned int, QHash<unsigned int, neb::host_group_member> > const&
                    get_host_group_members() const;
     QString const& get_service_description(
                      unsigned int host_id,
                      unsigned int service_id) const;
     QString const& get_service_group_name(unsigned int id) const;
-    QMultiHash<QPair<unsigned int, unsigned int>, neb::service_group_member> const&
+    QHash<QPair<unsigned int, unsigned int>,
+          QHash<unsigned int, neb::service_group_member> > const&
                    get_service_group_members() const;
     QString const& get_instance(unsigned int instance_id) const;
 
@@ -86,13 +87,14 @@ namespace         lua {
                    _hosts;
     QHash<unsigned int, neb::host_group>
                    _host_groups;
-    QMultiHash<unsigned int, neb::host_group_member>
+    QHash<unsigned int, QHash<unsigned int, neb::host_group_member> >
                    _host_group_members;
     QHash<QPair<unsigned int, unsigned int>, neb::service>
                    _services;
     QHash<unsigned int, neb::service_group>
                    _service_groups;
-    QMultiHash<QPair<unsigned int, unsigned int>, neb::service_group_member>
+    QHash<QPair<unsigned int, unsigned int>,
+          QHash<unsigned int, neb::service_group_member> >
                    _service_group_members;
     QHash<unsigned int, storage::index_mapping>
                    _index_mappings;

--- a/lua/inc/com/centreon/broker/lua/macro_cache.hh
+++ b/lua/inc/com/centreon/broker/lua/macro_cache.hh
@@ -26,6 +26,8 @@
 #  include "com/centreon/broker/neb/host_group_member.hh"
 #  include "com/centreon/broker/neb/instance.hh"
 #  include "com/centreon/broker/neb/service.hh"
+#  include "com/centreon/broker/neb/service_group.hh"
+#  include "com/centreon/broker/neb/service_group_member.hh"
 #  include "com/centreon/broker/persistent_cache.hh"
 #  include "com/centreon/broker/storage/index_mapping.hh"
 #  include "com/centreon/broker/storage/metric_mapping.hh"
@@ -55,6 +57,9 @@ namespace         lua {
     QString const& get_service_description(
                      unsigned int host_id,
                      unsigned int service_id) const;
+    QString const& get_service_group_name(unsigned int id) const;
+    QMultiHash<QPair<unsigned int, unsigned int>, neb::service_group_member> const&
+                   get_service_group_members() const;
     QString const& get_instance(unsigned int instance_id) const;
 
   private:
@@ -66,6 +71,8 @@ namespace         lua {
     void           _process_host_group(neb::host_group const& hg);
     void           _process_host_group_member(neb::host_group_member const& hgm);
     void           _process_service(neb::service const& s);
+    void           _process_service_group(neb::service_group const& sg);
+    void           _process_service_group_member(neb::service_group_member const& sgm);
     void           _process_index_mapping(storage::index_mapping const& im);
     void           _process_metric_mapping(storage::metric_mapping const& mm);
     void           _save_to_disk();
@@ -82,6 +89,10 @@ namespace         lua {
                    _host_group_members;
     QHash<QPair<unsigned int, unsigned int>, neb::service>
                    _services;
+    QHash<unsigned int, neb::service_group>
+                   _service_groups;
+    QMultiHash<QPair<unsigned int, unsigned int>, neb::service_group_member>
+                   _service_group_members;
     QHash<unsigned int, storage::index_mapping>
                    _index_mappings;
     QHash<unsigned int, storage::metric_mapping>

--- a/lua/inc/com/centreon/broker/lua/macro_cache.hh
+++ b/lua/inc/com/centreon/broker/lua/macro_cache.hh
@@ -75,6 +75,7 @@ namespace         lua {
     void           _process_service_group_member(neb::service_group_member const& sgm);
     void           _process_index_mapping(storage::index_mapping const& im);
     void           _process_metric_mapping(storage::metric_mapping const& mm);
+
     void           _save_to_disk();
 
     misc::shared_ptr<persistent_cache>

--- a/lua/src/broker_cache.cc
+++ b/lua/src/broker_cache.cc
@@ -16,7 +16,6 @@
 ** For more information : contact@centreon.com
 */
 
-#include <iostream>
 #include "com/centreon/broker/lua/broker_cache.hh"
 
 using namespace com::centreon::broker;
@@ -242,7 +241,7 @@ static int l_broker_cache_get_service_description(lua_State* L) {
 
 /**
  *  The get_servicegroups() method available in the Lua interpreter
- *  It returns a string.
+ *  It returns an array of objects, each one containing group_id and group_name.
  *
  *  @param L The Lua interpreter
  *
@@ -296,7 +295,6 @@ static int l_broker_cache_get_servicegroup_name(lua_State* L) {
 
   try {
     QString const& sg(cache->get_service_group_name(id));
-    std::cout << "??? get_service_group_name: " << sg.toStdString() << "\n";
     lua_pushstring(L, sg.toStdString().c_str());
   }
   catch (std::exception const& e) {

--- a/lua/src/broker_cache.cc
+++ b/lua/src/broker_cache.cc
@@ -16,6 +16,7 @@
 ** For more information : contact@centreon.com
 */
 
+#include <iostream>
 #include "com/centreon/broker/lua/broker_cache.hh"
 
 using namespace com::centreon::broker;
@@ -104,18 +105,18 @@ static int l_broker_cache_get_hostgroups(lua_State* L) {
   int i = 1;
   while (it != members.end() && it.key() == id) {
     neb::host_group_member const& hgm(it.value());
-    try {
-      QString const& hg_name(cache->get_host_group_name(hgm.group_id));
-      lua_pushstring(L, hg_name.toStdString().c_str());
-      lua_rawseti(L, -2, i);
-      ++i;
-    }
-    catch (std::exception const& e) {
-      (void) e;
-      lua_pop(L, 1);
-      lua_pushnil(L);
-      return 1;
-    }
+
+    lua_createtable(L, 0, 2);
+    lua_pushstring(L, "group_id");
+    lua_pushinteger(L, hgm.group_id);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "group_name");
+    lua_pushstring(L, hgm.group_name.toStdString().c_str());
+    lua_settable(L, -3);
+
+    lua_rawseti(L, -2, i);
+    ++i;
     ++it;
   }
   return 1;
@@ -240,6 +241,72 @@ static int l_broker_cache_get_service_description(lua_State* L) {
 }
 
 /**
+ *  The get_servicegroups() method available in the Lua interpreter
+ *  It returns a string.
+ *
+ *  @param L The Lua interpreter
+ *
+ *  @return 1
+ */
+static int l_broker_cache_get_servicegroups(lua_State* L) {
+  macro_cache const* cache(
+    *static_cast<macro_cache**>(luaL_checkudata(L, 1, "lua_broker_cache")));
+  unsigned int host_id(luaL_checkinteger(L, 2));
+  unsigned int service_id(luaL_checkinteger(L, 3));
+
+  QMultiHash<QPair<unsigned int, unsigned int>, neb::service_group_member> const& members(
+    cache->get_service_group_members());
+  QMultiHash<QPair<unsigned int, unsigned int>, neb::service_group_member>::const_iterator
+    it(members.find(qMakePair(host_id, service_id)));
+
+  lua_newtable(L);
+
+  int i = 1;
+  while (it != members.end() && it.key().first == host_id
+         && it.key().second == service_id) {
+    neb::service_group_member const& sgm(it.value());
+    lua_createtable(L, 0, 2);
+    lua_pushstring(L, "group_id");
+    lua_pushinteger(L, sgm.group_id);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "group_name");
+    lua_pushstring(L, sgm.group_name.toStdString().c_str());
+    lua_settable(L, -3);
+
+    lua_rawseti(L, -2, i);
+    ++i;
+    ++it;
+  }
+  return 1;
+}
+
+/**
+ *  The get_servicegroup_name() method available in the Lua interpreter
+ *  It returns a string.
+ *
+ *  @param L The Lua interpreter
+ *
+ *  @return 1
+ */
+static int l_broker_cache_get_servicegroup_name(lua_State* L) {
+  macro_cache const* cache(
+    *static_cast<macro_cache**>(luaL_checkudata(L, 1, "lua_broker_cache")));
+  int id(luaL_checkinteger(L, 2));
+
+  try {
+    QString const& sg(cache->get_service_group_name(id));
+    std::cout << "??? get_service_group_name: " << sg.toStdString() << "\n";
+    lua_pushstring(L, sg.toStdString().c_str());
+  }
+  catch (std::exception const& e) {
+    (void) e;
+    lua_pushnil(L);
+  }
+  return 1;
+}
+
+/**
  *  Load the Lua interpreter with the standard libraries
  *  and the broker lua sdk.
  *
@@ -262,6 +329,8 @@ void broker_cache::broker_cache_reg(lua_State* L, macro_cache const& cache) {
     { "get_instance_name", l_broker_cache_get_instance_name },
     { "get_metric_mapping", l_broker_cache_get_metric_mapping },
     { "get_service_description", l_broker_cache_get_service_description },
+    { "get_servicegroups", l_broker_cache_get_servicegroups },
+    { "get_servicegroup_name", l_broker_cache_get_servicegroup_name },
     { NULL, NULL }
   };
 

--- a/lua/src/broker_cache.cc
+++ b/lua/src/broker_cache.cc
@@ -34,30 +34,6 @@ static int l_broker_cache_destructor(lua_State* L) {
 }
 
 /**
- *  The get_hostname() method available in the Lua interpreter
- *  It returns a string.
- *
- *  @param L The Lua interpreter
- *
- *  @return 1
- */
-static int l_broker_cache_get_hostname(lua_State* L) {
-  macro_cache const* cache(
-    *static_cast<macro_cache**>(luaL_checkudata(L, 1, "lua_broker_cache")));
-  int id(luaL_checkinteger(L, 2));
-
-  try {
-    QString const& hst(cache->get_host_name(id));
-    lua_pushstring(L, hst.toStdString().c_str());
-  }
-  catch (std::exception const& e) {
-    (void) e;
-    lua_pushnil(L);
-  }
-  return 1;
-}
-
-/**
  *  The get_hostgroup_name() method available in the Lua interpreter
  *  It returns a string.
  *
@@ -82,41 +58,25 @@ static int l_broker_cache_get_hostgroup_name(lua_State* L) {
 }
 
 /**
- *  The get_hostgroup() method available in the Lua interpreter
+ *  The get_hostname() method available in the Lua interpreter
  *  It returns a string.
  *
  *  @param L The Lua interpreter
  *
  *  @return 1
  */
-static int l_broker_cache_get_hostgroups(lua_State* L) {
+static int l_broker_cache_get_hostname(lua_State* L) {
   macro_cache const* cache(
     *static_cast<macro_cache**>(luaL_checkudata(L, 1, "lua_broker_cache")));
   int id(luaL_checkinteger(L, 2));
 
-  QMultiHash<unsigned int, neb::host_group_member> const& members(
-    cache->get_host_group_members());
-  QMultiHash<unsigned int, neb::host_group_member>::const_iterator
-    it(members.find(id));
-
-  lua_newtable(L);
-
-  int i = 1;
-  while (it != members.end() && it.key() == id) {
-    neb::host_group_member const& hgm(it.value());
-
-    lua_createtable(L, 0, 2);
-    lua_pushstring(L, "group_id");
-    lua_pushinteger(L, hgm.group_id);
-    lua_settable(L, -3);
-
-    lua_pushstring(L, "group_name");
-    lua_pushstring(L, hgm.group_name.toStdString().c_str());
-    lua_settable(L, -3);
-
-    lua_rawseti(L, -2, i);
-    ++i;
-    ++it;
+  try {
+    QString const& hst(cache->get_host_name(id));
+    lua_pushstring(L, hst.toStdString().c_str());
+  }
+  catch (std::exception const& e) {
+    (void) e;
+    lua_pushnil(L);
   }
   return 1;
 }
@@ -240,6 +200,30 @@ static int l_broker_cache_get_service_description(lua_State* L) {
 }
 
 /**
+ *  The get_servicegroup_name() method available in the Lua interpreter
+ *  It returns a string.
+ *
+ *  @param L The Lua interpreter
+ *
+ *  @return 1
+ */
+static int l_broker_cache_get_servicegroup_name(lua_State* L) {
+  macro_cache const* cache(
+    *static_cast<macro_cache**>(luaL_checkudata(L, 1, "lua_broker_cache")));
+  int id(luaL_checkinteger(L, 2));
+
+  try {
+    QString const& sg(cache->get_service_group_name(id));
+    lua_pushstring(L, sg.toStdString().c_str());
+  }
+  catch (std::exception const& e) {
+    (void) e;
+    lua_pushnil(L);
+  }
+  return 1;
+}
+
+/**
  *  The get_servicegroups() method available in the Lua interpreter
  *  It returns an array of objects, each one containing group_id and group_name.
  *
@@ -281,25 +265,41 @@ static int l_broker_cache_get_servicegroups(lua_State* L) {
 }
 
 /**
- *  The get_servicegroup_name() method available in the Lua interpreter
+ *  The get_hostgroup() method available in the Lua interpreter
  *  It returns a string.
  *
  *  @param L The Lua interpreter
  *
  *  @return 1
  */
-static int l_broker_cache_get_servicegroup_name(lua_State* L) {
+static int l_broker_cache_get_hostgroups(lua_State* L) {
   macro_cache const* cache(
     *static_cast<macro_cache**>(luaL_checkudata(L, 1, "lua_broker_cache")));
   int id(luaL_checkinteger(L, 2));
 
-  try {
-    QString const& sg(cache->get_service_group_name(id));
-    lua_pushstring(L, sg.toStdString().c_str());
-  }
-  catch (std::exception const& e) {
-    (void) e;
-    lua_pushnil(L);
+  QMultiHash<unsigned int, neb::host_group_member> const& members(
+    cache->get_host_group_members());
+  QMultiHash<unsigned int, neb::host_group_member>::const_iterator
+    it(members.find(id));
+
+  lua_newtable(L);
+
+  int i = 1;
+  while (it != members.end() && it.key() == id) {
+    neb::host_group_member const& hgm(it.value());
+
+    lua_createtable(L, 0, 2);
+    lua_pushstring(L, "group_id");
+    lua_pushinteger(L, hgm.group_id);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "group_name");
+    lua_pushstring(L, hgm.group_name.toStdString().c_str());
+    lua_settable(L, -3);
+
+    lua_rawseti(L, -2, i);
+    ++i;
+    ++it;
   }
   return 1;
 }
@@ -320,15 +320,15 @@ void broker_cache::broker_cache_reg(lua_State* L, macro_cache const& cache) {
 
   luaL_Reg s_broker_cache_regs[] = {
     { "__gc", l_broker_cache_destructor },
-    { "get_hostname", l_broker_cache_get_hostname },
-    { "get_hostgroups", l_broker_cache_get_hostgroups },
     { "get_hostgroup_name", l_broker_cache_get_hostgroup_name },
+    { "get_hostgroups", l_broker_cache_get_hostgroups },
+    { "get_hostname", l_broker_cache_get_hostname },
     { "get_index_mapping", l_broker_cache_get_index_mapping },
     { "get_instance_name", l_broker_cache_get_instance_name },
     { "get_metric_mapping", l_broker_cache_get_metric_mapping },
     { "get_service_description", l_broker_cache_get_service_description },
-    { "get_servicegroups", l_broker_cache_get_servicegroups },
     { "get_servicegroup_name", l_broker_cache_get_servicegroup_name },
+    { "get_servicegroups", l_broker_cache_get_servicegroups },
     { NULL, NULL }
   };
 

--- a/lua/src/broker_utils.cc
+++ b/lua/src/broker_utils.cc
@@ -65,6 +65,12 @@ static void broker_json_encode_table(lua_State* L, std::ostringstream& oss) {
       }
     }
   }
+  else {
+    /* There are no key, the table is empty */
+    oss << "[]";
+    return ;
+  }
+
   if (!array) {
     oss << "{\"" << lua_tostring(L, -2) << "\":";
     broker_json_encode(L, oss);

--- a/lua/src/macro_cache.cc
+++ b/lua/src/macro_cache.cc
@@ -251,9 +251,7 @@ void macro_cache::_process_instance(instance_broadcast const& in) {
  */
 void macro_cache::_process_host(neb::host const& h) {
   logging::debug(logging::medium)
-    << "macro_cache: process host --- "
-    << "id = " << h.host_id
-    << " ; name = " << h.host_name;
+    << "lua: processing host '" << h.host_name << "' of id " << h.host_id;
   _hosts[h.host_id] = h;
 }
 
@@ -264,10 +262,11 @@ void macro_cache::_process_host(neb::host const& h) {
  */
 void macro_cache::_process_host_group(neb::host_group const& hg) {
   logging::debug(logging::medium)
-    << "macro_cache: process host group --- "
-    << "host group id = " << hg.id
-    << " ; name = " << hg.name;
-  _host_groups[hg.id] = hg;
+    << "lua: processing host group '" << hg.name << "' of id " << hg.id;
+  if (hg.enabled)
+    _host_groups[hg.id] = hg;
+  else
+    _host_groups.remove(hg.id);
 }
 
 /**
@@ -278,11 +277,13 @@ void macro_cache::_process_host_group(neb::host_group const& hg) {
 void macro_cache::_process_host_group_member(
        neb::host_group_member const& hgm) {
   logging::debug(logging::medium)
-    << "macro_cache: process host group member --- "
-    << "host id = " << hgm.host_id
-    << "host group id = " << hgm.group_id
-    << "host group name = " << hgm.group_name;
-  _host_group_members.insert(hgm.host_id, hgm);
+    << "lua: processing host group member "
+    << " (group_name: '" << hgm.group_name << "', group_id: " << hgm.group_id
+    << ", host_id: " << hgm.host_id << ")";
+  if (hgm.enabled)
+    _host_group_members.insert(hgm.host_id, hgm);
+  else
+    _host_group_members.remove(hgm.host_id);
 }
 
 /**
@@ -292,10 +293,8 @@ void macro_cache::_process_host_group_member(
  */
 void macro_cache::_process_service(neb::service const& s) {
   logging::debug(logging::medium)
-    << "macro_cache: process service --- "
-    << "host id = " << s.host_id
-    << " ; service id = " << s.service_id
-    << " ; description = " << s.service_description;
+    << "lua: processing service (" << s.host_id << ", " << s.service_id << ") "
+    << "(description: " << s.service_description << ")";
   _services[qMakePair(s.host_id, s.service_id)] = s;
 }
 
@@ -306,10 +305,11 @@ void macro_cache::_process_service(neb::service const& s) {
  */
 void macro_cache::_process_service_group(neb::service_group const& sg) {
   logging::debug(logging::medium)
-    << "macro_cache: process service group --- "
-    << "service group id = " << sg.id
-    << " ; name = " << sg.name;
-  _service_groups[sg.id] = sg;
+    << "lua: processing service group '" << sg.name << "' of id " << sg.id;
+  if (sg.enabled)
+    _service_groups[sg.id] = sg;
+  else
+    _service_groups.remove(sg.id);
 }
 
 /**
@@ -320,12 +320,14 @@ void macro_cache::_process_service_group(neb::service_group const& sg) {
 void macro_cache::_process_service_group_member(
        neb::service_group_member const& sgm) {
   logging::debug(logging::medium)
-    << "macro_cache: process service group member --- "
-    << "host id = " << sgm.host_id
-    << "service id = " << sgm.service_id
-    << "service group id = " << sgm.group_id
-    << "service group name = " << sgm.group_name;
-  _service_group_members.insert(qMakePair(sgm.host_id, sgm.service_id), sgm);
+    << "lua: processing service group member "
+    << " (group_name: '" << sgm.group_name << "', group_id: " << sgm.group_id
+    << ", host_id: " << sgm.host_id
+    << ", service_id: " << sgm.service_id << ")";
+  if (sgm.enabled)
+    _service_group_members.insert(qMakePair(sgm.host_id, sgm.service_id), sgm);
+  else
+    _service_group_members.remove(qMakePair(sgm.host_id, sgm.service_id));
 }
 
 /**
@@ -335,10 +337,8 @@ void macro_cache::_process_service_group_member(
  */
 void macro_cache::_process_index_mapping(storage::index_mapping const& im) {
   logging::debug(logging::medium)
-    << "macro_cache: process index mapping --- "
-    << "index id = " << im.index_id;
+    << "lua: processing index mapping (index_id: " << im.index_id << ")";
   _index_mappings[im.index_id] = im;
-  return ;
 }
 
 /**
@@ -348,8 +348,7 @@ void macro_cache::_process_index_mapping(storage::index_mapping const& im) {
  */
 void macro_cache::_process_metric_mapping(storage::metric_mapping const& mm) {
   logging::debug(logging::medium)
-    << "macro_cache: process metric mapping --- "
-    << "index id = " << mm.index_id;
+    << "lua: processing metric mapping (index_id: " << mm.index_id << ")";
   _metric_mappings[mm.metric_id] = mm;
 }
 

--- a/lua/src/macro_cache.cc
+++ b/lua/src/macro_cache.cc
@@ -373,12 +373,41 @@ void macro_cache::_save_to_disk() {
        ++it)
     _cache->add(misc::shared_ptr<io::data>(new neb::host(*it)));
 
+  for (QHash<unsigned int, neb::host_group>::const_iterator
+         it(_host_groups.begin()),
+         end(_host_groups.end());
+       it != end;
+       ++it)
+    _cache->add(misc::shared_ptr<io::data>(new neb::host_group(*it)));
+
+  for (QMultiHash<unsigned int, neb::host_group_member>::const_iterator
+         it(_host_group_members.begin()),
+         end(_host_group_members.end());
+       it != end;
+       ++it)
+    _cache->add(misc::shared_ptr<io::data>(new neb::host_group_member(*it)));
+
   for (QHash<QPair<unsigned int, unsigned int>, neb::service>::const_iterator
          it(_services.begin()),
          end(_services.end());
        it != end;
        ++it)
     _cache->add(misc::shared_ptr<io::data>(new neb::service(*it)));
+
+  for (QHash<unsigned int, neb::service_group>::const_iterator
+         it(_service_groups.begin()),
+         end(_service_groups.end());
+       it != end;
+       ++it)
+    _cache->add(misc::shared_ptr<io::data>(new neb::service_group(*it)));
+
+  for (QMultiHash<QPair<unsigned int, unsigned int>,
+                  neb::service_group_member>::const_iterator
+         it(_service_group_members.begin()),
+         end(_service_group_members.end());
+       it != end;
+       ++it)
+    _cache->add(misc::shared_ptr<io::data>(new neb::service_group_member(*it)));
 
   for (QHash<unsigned int, storage::index_mapping>::const_iterator
          it(_index_mappings.begin()),

--- a/lua/src/macro_cache.cc
+++ b/lua/src/macro_cache.cc
@@ -258,16 +258,6 @@ void macro_cache::_process_instance(instance_broadcast const& in) {
       ++it;
   }
 
-  for (QHash<unsigned int, neb::host_group>::iterator
-         it(_host_groups.begin()),
-         end(_host_groups.end());
-       it != end; ) {
-    if (it->poller_id == poller_id)
-      it = _host_groups.erase(it);
-    else
-      ++it;
-  }
-
   for (QHash<unsigned int,
              QHash<unsigned int, neb::host_group_member> >::iterator
          it(_host_group_members.begin()),
@@ -288,17 +278,6 @@ void macro_cache::_process_instance(instance_broadcast const& in) {
       services_removed << it.key();
       it = _services.erase(it);
     }
-    else
-      ++it;
-  }
-
-  for (QHash<QPair<unsigned int, unsigned int>,
-             QHash<unsigned int, neb::service_group_member> >::iterator
-         it(_service_group_members.begin()),
-         end(_service_group_members.end());
-       it != end; ) {
-    if (services_removed.contains(it.key()))
-      it = _service_group_members.erase(it);
     else
       ++it;
   }
@@ -327,8 +306,6 @@ void macro_cache::_process_host_group(neb::host_group const& hg) {
     << "lua: processing host group '" << hg.name << "' of id " << hg.id;
   if (hg.enabled)
     _host_groups[hg.id] = hg;
-  else
-    _host_groups.remove(hg.id);
 }
 
 /**
@@ -370,8 +347,6 @@ void macro_cache::_process_service_group(neb::service_group const& sg) {
     << "lua: processing service group '" << sg.name << "' of id " << sg.id;
   if (sg.enabled)
     _service_groups[sg.id] = sg;
-  else
-    _service_groups.remove(sg.id);
 }
 
 /**

--- a/lua/src/macro_cache.cc
+++ b/lua/src/macro_cache.cc
@@ -376,7 +376,9 @@ void macro_cache::_process_service_group_member(
  */
 void macro_cache::_process_index_mapping(storage::index_mapping const& im) {
   logging::debug(logging::medium)
-    << "lua: processing index mapping (index_id: " << im.index_id << ")";
+    << "lua: processing index mapping (index_id: " << im.index_id
+    << ", host_id: " << im.host_id
+    << ", service_id: " << im.service_id << ")";
   _index_mappings[im.index_id] = im;
 }
 
@@ -387,7 +389,8 @@ void macro_cache::_process_index_mapping(storage::index_mapping const& im) {
  */
 void macro_cache::_process_metric_mapping(storage::metric_mapping const& mm) {
   logging::debug(logging::medium)
-    << "lua: processing metric mapping (index_id: " << mm.index_id << ")";
+    << "lua: processing metric mapping (metric_id: " << mm.metric_id
+    << ", index_id: " << mm.index_id << ")";
   _metric_mappings[mm.metric_id] = mm;
 }
 

--- a/lua/test/lua.cc
+++ b/lua/test/lua.cc
@@ -541,3 +541,168 @@ TEST_F(LuaGenericTest, MetricMappingCacheTest) {
   RemoveFile(filename);
   RemoveFile("/tmp/log");
 }
+
+// When a query for a host group name is made
+// And the cache does not know about it
+// Then nil is returned by the lua method.
+TEST_F(LuaGenericTest, HostGroupCacheTestNameNotAvailable) {
+  QMap<QString, QVariant> conf;
+  std::string filename("/tmp/cache_test.lua");
+
+  CreateScript(filename, "function init(conf)\n"
+                         "  broker_log:set_parameters(3, '/tmp/log')\n"
+                         "  local hg = broker_cache:get_hostgroup_name(28)\n"
+                         "  broker_log:info(1, 'host group is ' .. tostring(hg))\n"
+                         "end\n\n"
+                         "function write(d)\n"
+                         "end\n");
+  std::auto_ptr<luabinding> binding(new luabinding(filename, conf, *_cache.get()));
+  QStringList lst(ReadFile("/tmp/log"));
+
+  ASSERT_TRUE(lst[0].contains("host group is nil"));
+  RemoveFile(filename);
+  RemoveFile("/tmp/log");
+}
+
+// When a query for a host group name is made
+// And the cache does know about it
+// Then the name is returned by the lua method.
+TEST_F(LuaGenericTest, HostGroupCacheTestName) {
+  QMap<QString, QVariant> conf;
+  std::string filename("/tmp/cache_test.lua");
+  shared_ptr<neb::host_group> hg(new neb::host_group);
+  hg->id = 28;
+  hg->name = strdup("centreon");
+  _cache->write(hg);
+
+  CreateScript(filename, "function init(conf)\n"
+                         "  broker_log:set_parameters(3, '/tmp/log')\n"
+                         "  local hg = broker_cache:get_hostgroup_name(28)\n"
+                         "  broker_log:info(1, 'host group is ' .. tostring(hg))\n"
+                         "end\n\n"
+                         "function write(d)\n"
+                         "end\n");
+  std::auto_ptr<luabinding> binding(new luabinding(filename, conf, *_cache.get()));
+  QStringList lst(ReadFile("/tmp/log"));
+
+  ASSERT_TRUE(lst[0].contains("host group is centreon"));
+  RemoveFile(filename);
+  RemoveFile("/tmp/log");
+}
+
+// When a query for host groups is made
+// And the host is attached to no group
+// Then an empty array is returned.
+TEST_F(LuaGenericTest, HostGroupCacheTestEmpty) {
+  QMap<QString, QVariant> conf;
+  std::string filename("/tmp/cache_test.lua");
+
+  CreateScript(filename, "function init(conf)\n"
+                         "  broker_log:set_parameters(3, '/tmp/log')\n"
+                         "  local hg = broker_cache:get_hostgroups(1)\n"
+                         "  broker_log:info(1, 'host group is ' .. broker.json_encode(hg))\n"
+                         "end\n\n"
+                         "function write(d)\n"
+                         "end\n");
+  std::auto_ptr<luabinding> binding(new luabinding(filename, conf, *_cache.get()));
+  QStringList lst(ReadFile("/tmp/log"));
+
+  ASSERT_TRUE(lst[0].contains("host group is []"));
+  RemoveFile(filename);
+  RemoveFile("/tmp/log");
+}
+
+// When a query for host groups is made
+// And the cache does know about them
+// Then an array is returned by the lua method.
+TEST_F(LuaGenericTest, HostGroupCacheTest) {
+  QMap<QString, QVariant> conf;
+  std::string filename("/tmp/cache_test.lua");
+  shared_ptr<neb::host_group> hg(new neb::host_group);
+  hg->id = 16;
+  hg->name = strdup("centreon1");
+  _cache->write(hg);
+  hg = new neb::host_group;
+  hg->id = 17;
+  hg->name = strdup("centreon2");
+  _cache->write(hg);
+  shared_ptr<neb::host> hst(new neb::host);
+  hst->host_id = 22;
+  hst->host_name = strdup("host_centreon");
+  _cache->write(hst);
+  shared_ptr<neb::host_group_member> member(new neb::host_group_member);
+  member->host_id = 22;
+  member->group_id = 16;
+  _cache->write(member);
+  member = new neb::host_group_member;
+  member->host_id = 22;
+  member->group_id = 17;
+  _cache->write(member);
+
+  CreateScript(filename, "function init(conf)\n"
+                         "  broker_log:set_parameters(3, '/tmp/log')\n"
+                         "  local hg = broker_cache:get_hostgroups(22)\n"
+                         "  for i,v in ipairs(hg) do\n"
+                         "    broker_log:info(1, 'member of ' .. v)\n"
+                         "  end\n"
+                         "end\n\n"
+                         "function write(d)\n"
+                         "end\n");
+  std::auto_ptr<luabinding> binding(new luabinding(filename, conf, *_cache.get()));
+  QStringList lst(ReadFile("/tmp/log"));
+
+  int first, second;
+  if (lst[0].contains("member of centreon1")) {
+    first = 0;
+    second = 1;
+  }
+  else {
+    first = 1;
+    second = 0;
+  }
+  ASSERT_TRUE(lst[first].contains("member of centreon1"));
+  ASSERT_TRUE(lst[second].contains("member of centreon2"));
+
+  RemoveFile(filename);
+  RemoveFile("/tmp/log");
+}
+
+// When a query for host groups is made
+// And the cache does know about them
+// And a host group name is missing
+// Then nil is returned. It is a case where the cache is badly built.
+TEST_F(LuaGenericTest, HostGroupCacheTestFailure) {
+  QMap<QString, QVariant> conf;
+  std::string filename("/tmp/cache_test.lua");
+  shared_ptr<neb::host_group> hg(new neb::host_group);
+  hg->id = 16;
+  hg->name = strdup("centreon1");
+  _cache->write(hg);
+  shared_ptr<neb::host> hst(new neb::host);
+  hst->host_id = 22;
+  hst->host_name = strdup("host_centreon");
+  _cache->write(hst);
+  shared_ptr<neb::host_group_member> member(new neb::host_group_member);
+  member->host_id = 22;
+  member->group_id = 16;
+  _cache->write(member);
+  member = new neb::host_group_member;
+  member->host_id = 22;
+  member->group_id = 17;
+  _cache->write(member);
+
+  CreateScript(filename, "function init(conf)\n"
+                         "  broker_log:set_parameters(3, '/tmp/log')\n"
+                         "  local hg = broker_cache:get_hostgroups(22)\n"
+                         "  broker_log:info(1, 'member of ' .. tostring(hg))\n"
+                         "end\n\n"
+                         "function write(d)\n"
+                         "end\n");
+  std::auto_ptr<luabinding> binding(new luabinding(filename, conf, *_cache.get()));
+  QStringList lst(ReadFile("/tmp/log"));
+
+  ASSERT_TRUE(lst[0].contains("member of nil"));
+
+  RemoveFile(filename);
+  RemoveFile("/tmp/log");
+}

--- a/lua/test/lua.cc
+++ b/lua/test/lua.cc
@@ -320,6 +320,27 @@ TEST_F(LuaGenericTest, JsonEncode) {
   RemoveFile("/tmp/log");
 }
 
+// Given an empty array,
+// Then json_encode() works well on it.
+TEST_F(LuaGenericTest, EmptyJsonEncode) {
+  QMap<QString, QVariant> conf;
+  std::string filename("/tmp/json_encode.lua");
+  CreateScript(filename, "function init(conf)\n"
+                         "  broker_log:set_parameters(3, '/tmp/log')\n"
+                         "  local a = {}\n"
+                         "  local json = broker.json_encode(a)\n"
+                         "  broker_log:info(1, 'empty array: ' .. json)\n"
+                         "end\n\n"
+                         "function write(d)\n"
+                         "end\n");
+  std::auto_ptr<luabinding> binding(new luabinding(filename, conf, *_cache.get()));
+  QStringList lst(ReadFile("/tmp/log"));
+
+  ASSERT_TRUE(lst[0].contains("INFO: empty array: []"));
+  RemoveFile(filename);
+  RemoveFile("/tmp/log");
+}
+
 // When a script is loaded, a new socket is created
 // And a call to connect is made with a good adress/port
 // Then it succeeds.

--- a/lua/test/lua.cc
+++ b/lua/test/lua.cc
@@ -657,20 +657,8 @@ TEST_F(LuaGenericTest, HostGroupCacheTest) {
   std::auto_ptr<luabinding> binding(new luabinding(filename, conf, *_cache.get()));
   QStringList lst(ReadFile("/tmp/log"));
 
-  int first, second;
-  if (lst[0].contains("\"group_id\":16")) {
-    first = 0;
-    second = 1;
-  }
-  else {
-    first = 1;
-    second = 0;
-  }
-  ASSERT_TRUE(lst[first].contains("\"group_id\":16"));
-  ASSERT_TRUE(lst[first].contains("\"group_name\":\"sixteen\""));
-
-  ASSERT_TRUE(lst[second].contains("\"group_id\":17"));
-  ASSERT_TRUE(lst[second].contains("\"group_name\":\"seventeen\""));
+  ASSERT_TRUE(lst[0].contains("\"group_id\":17"));
+  ASSERT_TRUE(lst[0].contains("\"group_name\":\"seventeen\""));
 
   RemoveFile(filename);
   RemoveFile("/tmp/log");
@@ -795,20 +783,8 @@ TEST_F(LuaGenericTest, ServiceGroupCacheTest) {
   std::auto_ptr<luabinding> binding(new luabinding(filename, conf, *_cache.get()));
   QStringList lst(ReadFile("/tmp/log"));
 
-  int first, second;
-  if (lst[0].contains("\"group_id\":16")) {
-    first = 0;
-    second = 1;
-  }
-  else {
-    first = 1;
-    second = 0;
-  }
-  ASSERT_TRUE(lst[first].contains("\"group_id\":16"));
-  ASSERT_TRUE(lst[first].contains("\"group_name\":\"seize\""));
-
-  ASSERT_TRUE(lst[second].contains("\"group_id\":17"));
-  ASSERT_TRUE(lst[second].contains("\"group_name\":\"dix-sept\""));
+  ASSERT_TRUE(lst[0].contains("\"group_id\":17"));
+  ASSERT_TRUE(lst[0].contains("\"group_name\":\"dix-sept\""));
 
   RemoveFile(filename);
   RemoveFile("/tmp/log");


### PR DESCRIPTION
The goal here is to add methods to the broker cache provided by the Lua module.

New methods are:
get_hostgroup_name(hg_id)
get_hostgroups(host_id)
get_servicegroup_name(sg_id)
get_servicegroups(host_id, service_id)

They are all tested in unit tests.
