### PR TITLE
fix(lua): Compiling broker with lua without liblua is now impossible

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -708,6 +708,9 @@ if (WITH_MODULE_LUA)
       break ()
     endif ()
   endforeach ()
+  if (NOT DEFINED LUA_VERSION_STRING)
+    message(FATAL_ERROR "No Lua development package found.")
+  endif ()
 endif ()
 
 # Influxdb module.


### PR DESCRIPTION
This is a little patch to cancel broker compilation if the development liblua library is not installed.
