### PR TITLE
update content with new repository CentOS7 and fixes dependency

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Centreon Broker'
-copyright = u'2012-2017, Centreon'
+copyright = u'2012-2018, Centreon'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -4,8 +4,8 @@
 Installation
 ############
 
-Centreon recommends using its official packages from the Centreon
-Entreprise Server (CES) repository. Most of Centreon' endorsed
+Centreon recommends using its official packages from the Centreon Open Sources
+version available free of charge on our repository (ex CES). Most of Centreon endorsed
 software are available as RPM packages.
 
 Alternatively, you can build and install your own version of this
@@ -19,18 +19,18 @@ notably).
 Using packages
 **************
 
-Centreon provides RPM for its products through Centreon Entreprise
-Server (CES). Open source products are freely available from our
-repository.
+Centreon provides RPM for its products through Centreon Open Sources version
+available free of charge on our repository (ex CES), Open source products are
+freely available from our repository.
 
-These packages are available for CentOS 6.
+These packages are available for CentOS 6 and 7 version.
 
 .. _user_installation_packages_prerequisites:
 
 Prerequisites
 =============
 
-In order to use RPM from the CES repository, you have to install the
+In order to use RPM from the COS repository, you have to install the
 appropriate repository.
 
 CentOS 6
@@ -38,10 +38,22 @@ CentOS 6
 
 Run the following commands as privileged user ::
 
-  $ wget http://yum.centreon.com/standard/3.0/stable/noarch/RPMS/ces-release-3.0-1.noarch.rpm
-  $ yum install --nogpgcheck ces-release-3.0-1.noarch.rpm
-  $ rm -f ces-release-3.0-1.noarch.rpm
+  $ wget http://yum.centreon.com/standard/3.4/el6/stable/noarch/RPMS/centreon-release-3.4-4.el6.noarch.rpm
+  $ yum install --nogpgcheck -y centreon-release-3.4-4.el6.noarch.rpm
+  $ rm -f centreon-release-3.4-4.el6.noarch.rpm
   $ yum clean all
+
+
+CentOS 7
+--------
+
+Run the following commands as privileged user ::
+
+  $ wget http://yum.centreon.com/standard/3.4/el7/stable/noarch/RPMS/centreon-release-3.4-4.el7.centos.noarch.rpm
+  $ yum install --nogpgcheck -y centreon-release-3.4-4.el7.centos.noarch.rpm
+  $ rm -f centreon-release-3.4-4.el6.noarch.rpm
+  $ yum clean all
+
 
 Install
 =======
@@ -92,10 +104,8 @@ further steps too.
 CentOS
 ------
 
-In CentOS you need to add manually cmake. After that you can
-install binary packages. Either use the Package Manager or the
-yum tool to install them. You should check packages version when
-necessary.
+Either use the Package Manager or the yum tool to install them. You should check
+packages version when necessary.
 
 Package required to build:
 
@@ -121,17 +131,17 @@ GnuTLS **(>= 2.8)**         gnutls-devel               Development files for gnu
 
 #. Install Centreon repository
 
-   You need to install Centreon Entreprise Server (CES) repos file as
+   You need to install Centreon Open Sources (COS) repository file as
    explained :ref:`user_installation_packages_prerequisites` to use some
    specific package version.
+
+#. Install cmake and lua-devel ::
+
+  $ yum install cmake lua-devel
 
 #. Install RRDTool ::
 
    $ yum install rrdtool-devel
-
-#. Install cmake ::
-
-   $ yum install cmake
 
 #. Install Qt framework ::
 
@@ -181,7 +191,7 @@ GnuTLS **(>= 2.8)**         libgnutls28-dev  Development files for gnutls.
 
 #. Install compilation tools ::
 
-     $ apt-get install build-essential cmake
+     $ apt-get install build-essential cmake lua5.2-dev
 
 #. Install RRDTool ::
 
@@ -258,7 +268,7 @@ installed run this ::
   $ git clone https://github.com/centreon/centreon-broker
 
 Or You can get the latest Centreon Broker's sources from its
-`download website <http://www.centreon.com/Centreon-Extensions/centreon-broker-download.html>`_
+`download website <https://download.centreon.com/>`_
 Once downloaded, extract it ::
 
   $ tar xzf centreon-broker.tar.gz

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -302,11 +302,13 @@ following commands ::
   $ cmake .
 
 .. note::
-    If you are using Debian Strech or Ubuntu Xenial, you need to add the following
-    statement in the **CMakeLists.txt** file (directory `build`), use the command
-    bellow to add ::
-
-      $ sed -i '26iset(CMAKE_CXX_FLAGS "-std=c++98 -fpermissive")' CMakeLists.txt
+    If you are using Debian Strech or Ubuntu Xenial, you need set some flags to
+    build source compatible with the new compile tools. For this, set the variable
+    `CMAKE_CXX_FLAGS` and compile as show bellow ::
+      
+      $ cd /path_to_centreon_broker/build
+      $ export CXXFLAGS="-std=c++98 -Wno-long-long"
+      $ cmake .
 
 Your Centreon Broker can be tweaked to your particular needs using
 CMake's variable system. Variables can be set like this ::

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -19,8 +19,8 @@ notably).
 Using packages
 **************
 
-Centreon provides RPM for its products through Centreon Open Sources version
-available free of charge on our repository (ex CES), Open source products are
+Centreon provides RPM for its products through Centreon Open Sources (COS) version
+available free of charge on our repository, Open source products are
 freely available from our repository.
 
 These packages are available for CentOS 6 and 7 version.

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -302,10 +302,10 @@ following commands ::
   $ cmake .
 
 .. note::
-    If you are using Debian Strech or Ubuntu Xenial, you need set some flags to
+    If you are using Debian Stretch or Ubuntu Xenial, you need set some flags to
     build source compatible with the new compile tools. For this, set the variable
-    `CMAKE_CXX_FLAGS` and compile as show bellow ::
-      
+    `CXXFLAGS` and compile as show bellow ::
+
       $ cd /path_to_centreon_broker/build
       $ export CXXFLAGS="-std=c++98 -Wno-long-long"
       $ cmake .

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -51,7 +51,7 @@ Run the following commands as privileged user ::
 
   $ wget http://yum.centreon.com/standard/3.4/el7/stable/noarch/RPMS/centreon-release-3.4-4.el7.centos.noarch.rpm
   $ yum install --nogpgcheck -y centreon-release-3.4-4.el7.centos.noarch.rpm
-  $ rm -f centreon-release-3.4-4.el6.noarch.rpm
+  $ rm -f centreon-release-3.4-4.el7.centos.noarch.rpm
   $ yum clean all
 
 
@@ -135,9 +135,13 @@ GnuTLS **(>= 2.8)**         gnutls-devel               Development files for gnu
    explained :ref:`user_installation_packages_prerequisites` to use some
    specific package version.
 
-#. Install cmake and lua-devel ::
+#. Install cmake ::
 
-  $ yum install cmake lua-devel
+   $ yum install cmake
+
+#. Install lua-devel ::
+
+   $ yum install lua-devel
 
 #. Install RRDTool ::
 
@@ -156,12 +160,12 @@ GnuTLS **(>= 2.8)**         gnutls-devel               Development files for gnu
    Depending on your Qt installation, qmake could already be available
    or in a path like /usr/lib64/qt4/bin/.
 
-::
+   ::
 
-   $ export PATH="$PATH:/usr/lib64/qt4/bin"
-   $ qmake --version # (or qmake-qt4 --version)
-   QMake version 2.01a
-   Using Qt version 4.8.7 in /usr/lib/x86_64-linux-gnu
+     $ export PATH="$PATH:/usr/lib64/qt4/bin"
+     $ qmake --version # (or qmake-qt4 --version)
+     QMake version 2.01a
+     Using Qt version 4.8.7 in /usr/lib/x86_64-linux-gnu
 
 Debian/Ubuntu
 -------------
@@ -191,19 +195,33 @@ GnuTLS **(>= 2.8)**         libgnutls28-dev  Development files for gnutls.
 
 #. Install compilation tools ::
 
-     $ apt-get install build-essential cmake lua5.2-dev
+   $ apt-get install build-essential
+
+#. Install cmake ::
+
+   $ apt-get install cmake
+
+#. Imstall lua-dev
+
+   For Debian Jessie / Ubuntu 14.04 ::
+
+      $ apt-get install lua5.2-dev
+
+   For Debian Stretch / Ubuntu Xenial ::
+
+      $ apt-get install lua5.3-dev
 
 #. Install RRDTool ::
 
-     $ apt-get install librrd-dev
+   $ apt-get install librrd-dev
 
 #. Install Qt framework ::
 
-     $ apt-get install libqt4-dev libqt4-sql-mysql
+   $ apt-get install libqt4-dev libqt4-sql-mysql
 
 #. Install GnuTLS ::
 
-     $ apt-get install libgnutls28-dev
+   $ apt-get install libgnutls28-dev
 
 OpenSUSE
 --------
@@ -233,19 +251,19 @@ GnuTLS **(>= 2.8)**         libgnutls-devel   Development files for gnutls.
 
 #. Install compilation tools ::
 
-     $ zypper install gcc gcc-c++ make cmake libqt4-devel rrdtool-devel
+   $ zypper install gcc gcc-c++ make cmake libqt4-devel rrdtool-devel
 
 #. Install RRDTool ::
 
-     $ zypper install rrdtool-devel
+   $ zypper install rrdtool-devel
 
 #. Install Qt framework ::
 
-     $ zypper install libqt4-devel libqt4-sql-mysql
+   $ zypper install libqt4-devel libqt4-sql-mysql
 
 #. Install GnuTls ::
 
-     $ zypper install libgnutls-devel
+   $ zypper install libgnutls-devel
 
 
 Raspberry Pi (Raspbian)
@@ -282,6 +300,13 @@ following commands ::
 
   $ cd /path_to_centreon_broker/build
   $ cmake .
+
+.. note::
+    If you are using Debian Strech or Ubuntu Xenial, you need to add the following
+    statement in the **CMakeLists.txt** file (directory `build`), use the command
+    bellow to add ::
+
+      $ sed -i '26iset(CMAKE_CXX_FLAGS "-std=c++98 -fpermissive")' CMakeLists.txt
 
 Your Centreon Broker can be tweaked to your particular needs using
 CMake's variable system. Variables can be set like this ::


### PR DESCRIPTION
Add instructions to use the new repository and update instructions to install packages.
Fix depencies to build source.
Tested installation based on documentation.

- Centos 6
- Centos 7
- Debian Jessie
- Debian Stretch
- Ubuntu 14.04
- Ubuntu 16.04