### PR TITLE
Watchdog

### DIFF
--- a/watchdog/src/application.cc
+++ b/watchdog/src/application.cc
@@ -214,8 +214,10 @@ void application::_quit() {
          it(_instances.begin()),
          end(_instances.end());
        it != end;
-       ++it)
+       ++it) {
     it->second->stop_instance();
+    it->second->waitForFinished();
+  }
   logging::info(logging::medium)
     << "watchdog: shutdown sequence completed, exiting watchdog";
   exit();

--- a/watchdog/src/application.cc
+++ b/watchdog/src/application.cc
@@ -214,10 +214,14 @@ void application::_quit() {
          it(_instances.begin()),
          end(_instances.end());
        it != end;
-       ++it) {
+       ++it)
     it->second->stop_instance();
+  for (std::map<std::string, instance*>::iterator
+         it(_instances.begin()),
+         end(_instances.end());
+       it != end;
+       ++it)
     it->second->waitForFinished();
-  }
   logging::info(logging::medium)
     << "watchdog: shutdown sequence completed, exiting watchdog";
   exit();


### PR DESCRIPTION
When the application asked for processes to stop, it could exit before all processes to be finished.
And then, when the service was restarted, it was possible to have several configurations of the same broker running at the same time.
This fix consists in waiting for each process to correctly stop before exiting.