### PR TITLE
update broker::lua::brocker_utils to not create lua errors on storage…

### DIFF
--- a/doc/exploit/stream_connectors.rst
+++ b/doc/exploit/stream_connectors.rst
@@ -154,11 +154,12 @@ methods, *broker* is just a table containing them. We can find here:
    returned as string by the function.
 2. ``json_decode(json)`` that converts into Lua object a json string. The object
    is directly returned by the method.
-3. ``parse_perfdata(str)`` that takes as argument a string containing perfdata
-   and returns a table containing the values retrieved from the perfdata. A
-   second boolean argument is available. If it is *true*, the returned table is
-   larger and gives all the details on the metrics as well as the *warning* and
-   *critical* thresholds.
+3. ``parse_perfdata(str)`` that takes as argument a string containing perfdata.
+   A second boolean argument is available. If it is *true*, the returned table
+   is larger and gives all the details on the metrics as well as the *warning*
+   and *critical* thresholds. On success it returns a table containing the
+   values retrieved from the perfdata. On failure it returns a nil object
+   and an error description string.
 
 .. code-block:: lua
 
@@ -202,10 +203,14 @@ Here is an example showing the possibilities of the ``parse_perfdata`` function.
 
 .. code-block:: lua
 
-  local perf = broker.parse_perfdata(" 'one value'=2s;3;5;0;9 'a b c'=3.14KB;0.8;1;0;10")
+  local perf, err_str = broker.parse_perfdata(" 'one value'=2s;3;5;0;9 'a b c'=3.14KB;0.8;1;0;10")
 
-  for i,v in pairs(perf) do
-    print(i .. " => " .. tostring(v))
+  if perf then
+    for i,v in pairs(perf) do
+      print(i .. " => " .. tostring(v))
+    end
+  else
+    print("parse_perfdata error: " .. err_str)
   end
 
 should return something like this:
@@ -219,11 +224,15 @@ If now, we call the same function with *true* as second argument:
 
 .. code-block:: lua
 
-  local perf = broker.parse_perfdata("pl=45%;40;80;0;100", true)
+  local perf, err_str = broker.parse_perfdata("pl=45%;40;80;0;100", true)
 
-  print("Content of 'pl'")
-  for i,v in pairs(perf['pl']) do
-    print(i .. " => " .. tostring(v))
+  if perf then
+    print("Content of 'pl'")
+    for i,v in pairs(perf['pl']) do
+      print(i .. " => " .. tostring(v))
+    end
+  else
+    print("parse_perfdata error: " .. err_str)
   end
 
 should return something like this:

--- a/doc/release_notes/broker18.10.rst
+++ b/doc/release_notes/broker18.10.rst
@@ -12,6 +12,12 @@ Escape backslash in JSON encoding/decoding functions
 In previous versions backslash was not handled as a special character
 leading to invalid JSON encoding and decoding.
 
+Return an error in Lua perfdata parsing function
+================================================
+
+Before this fix when we were calling parse_perfdata with an invalid
+perf string, the lua was not working.
+
 ************
 Enhancements
 ************

--- a/lua/src/broker_utils.cc
+++ b/lua/src/broker_utils.cc
@@ -285,10 +285,9 @@ static int l_broker_parse_perfdata(lua_State* L) {
     p.parse_perfdata(perf_data, pds);
   }
   catch (storage::exceptions::perfdata const& e) {
-    std::stringstream oss;
-    oss << "storage: error while parsing perfdata << "
-            << perf_data << " >>: " << e.what();
-    luaL_error(L, oss.str().c_str());
+    lua_pushnil(L);
+    lua_pushstring(L, e.what());
+    return 2;
   }
   lua_createtable(L, 0, pds.size());
   for (QList<storage::perfdata>::iterator


### PR DESCRIPTION
Update broker::lua::brocker_utils to not create lua errors on storage::parser::parse_perfdata() exceptions.

Before this fix when we were calling parse_perfdata with an invalid perf string, the lua was not working.
Now parse_perfdata return another return value. If this second return value is nil parse_perfdata succeed if not it contains the error string.

Here is an example of a proper use of parse_perfdata with a bad perf value in lua : 

perf, err_msg = broker.parse_perfdata(\" 'events'=;;;0;\")
if err_msg == nil then
    broker_log:info(1, broker.json_encode(perf))
else
    broker_log:info(1, err_msg)
end