### PR TITLE
fix(influxdb): The cache was badly removed on cbd restart.

### DIFF
--- a/influxdb/inc/com/centreon/broker/influxdb/macro_cache.hh
+++ b/influxdb/inc/com/centreon/broker/influxdb/macro_cache.hh
@@ -22,7 +22,6 @@
 #  include <map>
 #  include <string>
 #  include <QHash>
-#  include "com/centreon/broker/instance_broadcast.hh"
 #  include "com/centreon/broker/io/factory.hh"
 #  include "com/centreon/broker/namespace.hh"
 #  include "com/centreon/broker/misc/shared_ptr.hh"
@@ -60,7 +59,7 @@ namespace         influxdb {
                    macro_cache(macro_cache const& f);
     macro_cache&   operator=(macro_cache const& f);
 
-    void           _process_instance(instance_broadcast const& in);
+    void           _process_instance(neb::instance const& in);
     void           _process_host(neb::host const& h);
     void           _process_service(neb::service const& s);
     void           _process_index_mapping(storage::index_mapping const& im);
@@ -69,7 +68,7 @@ namespace         influxdb {
 
     misc::shared_ptr<persistent_cache>
                    _cache;
-    QHash<unsigned int, instance_broadcast>
+    QHash<unsigned int, neb::instance>
                    _instances;
     QHash<unsigned int, neb::host>
                    _hosts;

--- a/influxdb/src/macro_cache.cc
+++ b/influxdb/src/macro_cache.cc
@@ -134,13 +134,13 @@ QString const& macro_cache::get_service_description(
  *  @return   The name of the instance.
  */
 QString const& macro_cache::get_instance(unsigned int instance_id) const {
-  QHash<unsigned int, instance_broadcast>::const_iterator
+  QHash<unsigned int, neb::instance>::const_iterator
     found(_instances.find(instance_id));
   if (found == _instances.end())
     throw (exceptions::msg()
            << "influxdb: could not find information on instance "
            << instance_id);
-  return (found->poller_name);
+  return (found->name);
 }
 
 /**
@@ -152,8 +152,8 @@ void macro_cache::write(misc::shared_ptr<io::data> const& data) {
   if (data.isNull())
     return ;
 
-  if (data->type() == instance_broadcast::static_type())
-    _process_instance(data.ref_as<instance_broadcast const>());
+  if (data->type() == neb::instance::static_type())
+    _process_instance(data.ref_as<neb::instance const>());
   else if (data->type() == neb::host::static_type())
     _process_host(data.ref_as<neb::host const>());
   else if (data->type() == neb::service::static_type())
@@ -169,7 +169,7 @@ void macro_cache::write(misc::shared_ptr<io::data> const& data) {
  *
  *  @param in  The event.
  */
-void macro_cache::_process_instance(instance_broadcast const& in) {
+void macro_cache::_process_instance(neb::instance const& in) {
   _instances[in.poller_id] = in;
 }
 
@@ -216,12 +216,12 @@ void macro_cache::_process_metric_mapping(storage::metric_mapping const& mm) {
 void macro_cache::_save_to_disk() {
   _cache->transaction();
 
-  for (QHash<unsigned int, instance_broadcast>::const_iterator
+  for (QHash<unsigned int, neb::instance>::const_iterator
          it(_instances.begin()),
          end(_instances.end());
        it != end;
        ++it)
-    _cache->add(misc::shared_ptr<io::data>(new instance_broadcast(*it)));
+    _cache->add(misc::shared_ptr<io::data>(new neb::instance(*it)));
 
   for (QHash<unsigned int, neb::host>::const_iterator
          it(_hosts.begin()),


### PR DESCRIPTION
Configure the influxdb output on your centreon. You should configure the output such that hostnames or service descriptions are used in the output.

Restart cbd, you won't have hostnames and service descriptions. To have them again, restart engine.

This patch fixes that. With it, when you restart cbd, the cache is correctly reloaded.
