### PR TITLE
enh(c++11): only use std::shared_ptr in broker

### DIFF
--- a/bam/test/time/check_timeperiod.cc
+++ b/bam/test/time/check_timeperiod.cc
@@ -27,7 +27,6 @@
 #include "com/centreon/broker/time/timezone_manager.hh"
 #include "com/centreon/broker/config/applier/init.hh"
 #include "com/centreon/broker/exceptions/msg.hh"
-#include "com/centreon/broker/misc/shared_ptr.hh"
 
 #ifndef __THROW
 #  define __THROW

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -23,7 +23,7 @@
 # Set necessary settings.
 cmake_minimum_required(VERSION 2.8)
 project("Centreon Broker" C CXX)
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(PROJECT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/..")
 set(INC_DIR "${PROJECT_SOURCE_DIR}/core/inc")
 include_directories("${INC_DIR}")

--- a/core/test/multiplexing/subscriber/ctor_default.cc
+++ b/core/test/multiplexing/subscriber/ctor_default.cc
@@ -20,7 +20,6 @@
 #include "com/centreon/broker/config/applier/init.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/io/raw.hh"
-#include "com/centreon/broker/misc/shared_ptr.hh"
 #include "com/centreon/broker/multiplexing/engine.hh"
 #include "com/centreon/broker/multiplexing/muxer.hh"
 #include "com/centreon/broker/multiplexing/subscriber.hh"

--- a/neb/inc/com/centreon/engine/broker/handle.hh
+++ b/neb/inc/com/centreon/engine/broker/handle.hh
@@ -23,7 +23,6 @@
 #  include <string>
 #  include "com/centreon/engine/namespace.hh"
 #  include "com/centreon/library.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/broker/handle.hh
+++ b/neb/inc/com/centreon/engine/broker/handle.hh
@@ -62,6 +62,7 @@ namespace                    broker {
     void                     open(
                                std::string const& filename,
                                std::string const& args);
+    void                     reload();
     void                     set_author(
                                std::string const& author);
     void                     set_copyright(

--- a/neb/inc/com/centreon/engine/broker/loader.hh
+++ b/neb/inc/com/centreon/engine/broker/loader.hh
@@ -24,7 +24,6 @@
 #  include <string>
 #  include "com/centreon/engine/broker/handle.hh"
 #  include "com/centreon/engine/namespace.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/commands/connector.hh
+++ b/neb/inc/com/centreon/engine/commands/connector.hh
@@ -28,7 +28,6 @@
 #  include "com/centreon/engine/namespace.hh"
 #  include "com/centreon/process.hh"
 #  include "com/centreon/process_listener.hh"
-#  include "com/centreon/shared_ptr.hh"
 #  include "com/centreon/unordered_hash.hh"
 
 CCE_BEGIN()
@@ -108,7 +107,7 @@ namespace                commands {
     concurrency::condvar _cv_query;
     std::string          _data_available;
     bool                 _is_running;
-    umap<unsigned long, shared_ptr<query_info> >
+    umap<unsigned long, std::shared_ptr<query_info> >
                          _queries;
     bool                 _query_quit_ok;
     bool                 _query_version_ok;

--- a/neb/inc/com/centreon/engine/commands/set.hh
+++ b/neb/inc/com/centreon/engine/commands/set.hh
@@ -23,7 +23,6 @@
 #  include <string>
 #  include "com/centreon/engine/commands/command.hh"
 #  include "com/centreon/engine/namespace.hh"
-#  include "com/centreon/shared_ptr.hh"
 #  include "com/centreon/unordered_hash.hh"
 
 CCE_BEGIN()

--- a/neb/inc/com/centreon/engine/configuration/applier/member.hh
+++ b/neb/inc/com/centreon/engine/configuration/applier/member.hh
@@ -23,7 +23,6 @@
 #  include <list>
 #  include <string>
 #  include "com/centreon/engine/namespace.hh"
-#  include "com/centreon/shared_ptr.hh"
 #  include "com/centreon/unordered_hash.hh"
 
 struct command_struct;

--- a/neb/inc/com/centreon/engine/configuration/applier/object.hh
+++ b/neb/inc/com/centreon/engine/configuration/applier/object.hh
@@ -27,7 +27,6 @@
 #  include "com/centreon/engine/configuration/applier/difference.hh"
 #  include "com/centreon/engine/namespace.hh"
 #  include "com/centreon/engine/shared.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 #  define NULL_IF_EMPTY(str) ((str).empty() ? NULL : (str).c_str())
 

--- a/neb/inc/com/centreon/engine/configuration/applier/state.hh
+++ b/neb/inc/com/centreon/engine/configuration/applier/state.hh
@@ -107,13 +107,13 @@ namespace           configuration {
                     contactgroups_find(configuration::contactgroup::key_type const& k) const;
       umap<std::string, shared_ptr<contactgroup_struct> >::iterator
                     contactgroups_find(configuration::contactgroup::key_type const& k);
-      umap<std::string, shared_ptr<host_struct> > const&
+      umap<unsigned int, shared_ptr<host_struct> > const&
                     hosts() const throw ();
-      umap<std::string, shared_ptr<host_struct> >&
+      umap<unsigned int, shared_ptr<host_struct> >&
                     hosts() throw ();
-      umap<std::string, shared_ptr<host_struct> >::const_iterator
+      umap<unsigned int, shared_ptr<host_struct> >::const_iterator
                     hosts_find(configuration::host::key_type const& k) const;
-      umap<std::string, shared_ptr<host_struct> >::iterator
+      umap<unsigned int, shared_ptr<host_struct> >::iterator
                     hosts_find(configuration::host::key_type const& k);
       umultimap<std::string, shared_ptr<hostdependency_struct> > const&
                     hostdependencies() const throw ();
@@ -139,13 +139,13 @@ namespace           configuration {
                     hostgroups_find(configuration::hostgroup::key_type const& k) const;
       umap<std::string, shared_ptr<hostgroup_struct> >::iterator
                     hostgroups_find(configuration::hostgroup::key_type const& k);
-      umap<std::pair<std::string, std::string>, shared_ptr<service_struct> > const&
+      umap<std::pair<unsigned int, unsigned int>, shared_ptr<service_struct> > const&
                     services() const throw ();
-      umap<std::pair<std::string, std::string>, shared_ptr<service_struct> >&
+      umap<std::pair<unsigned int, unsigned int>, shared_ptr<service_struct> >&
                     services() throw ();
-      umap<std::pair<std::string, std::string>, shared_ptr<service_struct> >::const_iterator
+      umap<std::pair<unsigned int, unsigned int>, shared_ptr<service_struct> >::const_iterator
                     services_find(configuration::service::key_type const& k) const;
-      umap<std::pair<std::string, std::string>, shared_ptr<service_struct> >::iterator
+      umap<std::pair<unsigned int, unsigned int>, shared_ptr<service_struct> >::iterator
                     services_find(configuration::service::key_type const& k);
       umultimap<std::pair<std::string, std::string>, shared_ptr<servicedependency_struct> > const&
                     servicedependencies() const throw ();
@@ -229,7 +229,7 @@ namespace           configuration {
                     _contactgroups;
       concurrency::condvar
                     _cv_lock;
-      umap<std::string, shared_ptr<host_struct> >
+      umap<unsigned int, shared_ptr<host_struct> >
                     _hosts;
       umultimap<std::string, shared_ptr<hostdependency_struct> >
                     _hostdependencies;
@@ -241,7 +241,7 @@ namespace           configuration {
                     _lock;
       processing_state
                     _processing_state;
-      umap<std::pair<std::string, std::string>, shared_ptr<service_struct> >
+      umap<std::pair<unsigned int, unsigned int>, shared_ptr<service_struct> >
                     _services;
       umultimap<std::pair<std::string, std::string>, shared_ptr<servicedependency_struct> >
                     _servicedependencies;

--- a/neb/inc/com/centreon/engine/configuration/applier/state.hh
+++ b/neb/inc/com/centreon/engine/configuration/applier/state.hh
@@ -27,7 +27,6 @@
 #  include "com/centreon/engine/configuration/applier/difference.hh"
 #  include "com/centreon/engine/configuration/state.hh"
 #  include "com/centreon/engine/namespace.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 // Forward declaration.
 struct command_struct;

--- a/neb/inc/com/centreon/engine/configuration/command.hh
+++ b/neb/inc/com/centreon/engine/configuration/command.hh
@@ -66,8 +66,8 @@ namespace                  configuration {
     static setters const   _setters[];
   };
 
-  typedef shared_ptr<command> command_ptr;
-  typedef std::set<command>   set_command;
+  typedef std::shared_ptr<command> command_ptr;
+  typedef std::set<command>        set_command;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/configuration/connector.hh
+++ b/neb/inc/com/centreon/engine/configuration/connector.hh
@@ -65,8 +65,8 @@ namespace                  configuration {
     static setters const   _setters[];
   };
 
-  typedef shared_ptr<connector> connector_ptr;
-  typedef std::set<connector>   set_connector;
+  typedef std::shared_ptr<connector> connector_ptr;
+  typedef std::set<connector>        set_connector;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/configuration/contact.hh
+++ b/neb/inc/com/centreon/engine/configuration/contact.hh
@@ -123,8 +123,8 @@ namespace                  configuration {
     static setters const   _setters[];
   };
 
-  typedef shared_ptr<contact> contact_ptr;
-  typedef std::set<contact>   set_contact;
+  typedef std::shared_ptr<contact> contact_ptr;
+  typedef std::set<contact>        set_contact;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/configuration/contactgroup.hh
+++ b/neb/inc/com/centreon/engine/configuration/contactgroup.hh
@@ -73,8 +73,8 @@ namespace                  configuration {
     static setters const   _setters[];
   };
 
-  typedef shared_ptr<contactgroup> contactgroup_ptr;
-  typedef std::set<contactgroup>   set_contactgroup;
+  typedef std::shared_ptr<contactgroup> contactgroup_ptr;
+  typedef std::set<contactgroup>        set_contactgroup;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/configuration/host.hh
+++ b/neb/inc/com/centreon/engine/configuration/host.hh
@@ -46,9 +46,9 @@ namespace                  configuration {
       flapping = (1 << 3),
       downtime = (1 << 4)
     };
-    typedef std::string    key_type;
+    typedef unsigned int   key_type;
 
-                           host(key_type const& key = "");
+                           host(key_type const& key = 0);
                            host(host const& other);
                            ~host() throw ();
     host&                  operator=(host const& other);

--- a/neb/inc/com/centreon/engine/configuration/host.hh
+++ b/neb/inc/com/centreon/engine/configuration/host.hh
@@ -221,7 +221,8 @@ namespace                  configuration {
     std::string            _vrml_image;
   };
 
-  typedef shared_ptr<host>  host_ptr;
+  typedef std::shared_ptr<host>
+                            host_ptr;
   typedef std::list<host>   list_host;
   typedef std::set<host>    set_host;
 }

--- a/neb/inc/com/centreon/engine/configuration/hostdependency.hh
+++ b/neb/inc/com/centreon/engine/configuration/hostdependency.hh
@@ -108,8 +108,8 @@ namespace                  configuration {
     static setters const   _setters[];
   };
 
-  typedef shared_ptr<hostdependency>  hostdependency_ptr;
-  typedef std::set<hostdependency>    set_hostdependency;
+  typedef std::shared_ptr<hostdependency>  hostdependency_ptr;
+  typedef std::set<hostdependency>         set_hostdependency;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/configuration/hostescalation.hh
+++ b/neb/inc/com/centreon/engine/configuration/hostescalation.hh
@@ -106,8 +106,8 @@ namespace                  configuration {
     static setters const   _setters[];
   };
 
-  typedef shared_ptr<hostescalation> hostescalation_ptr;
-  typedef std::set<hostescalation>   set_hostescalation;
+  typedef std::shared_ptr<hostescalation> hostescalation_ptr;
+  typedef std::set<hostescalation>        set_hostescalation;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/configuration/hostgroup.hh
+++ b/neb/inc/com/centreon/engine/configuration/hostgroup.hh
@@ -85,8 +85,8 @@ namespace                  configuration {
     static setters const   _setters[];
   };
 
-  typedef shared_ptr<hostgroup> hostgroup_ptr;
-  typedef std::set<hostgroup>   set_hostgroup;
+  typedef std::shared_ptr<hostgroup> hostgroup_ptr;
+  typedef std::set<hostgroup>        set_hostgroup;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/configuration/object.hh
+++ b/neb/inc/com/centreon/engine/configuration/object.hh
@@ -27,7 +27,6 @@
 #  include <string>
 #  include "com/centreon/engine/namespace.hh"
 #  include "com/centreon/engine/string.hh"
-#  include "com/centreon/shared_ptr.hh"
 #  include "com/centreon/unordered_hash.hh"
 
 typedef std::list<std::string>             list_string;
@@ -65,14 +64,14 @@ namespace                  configuration {
     bool                   operator!=(
                              object const& right) const throw ();
     virtual void           check_validity() const = 0;
-    static shared_ptr<object>
+    static std::shared_ptr<object>
                            create(std::string const& type_name);
     virtual void           merge(object const& obj) = 0;
     std::string const&     name() const throw ();
     virtual bool           parse(char const* key, char const* value);
     virtual bool           parse(std::string const& line);
     void                   resolve_template(
-                             umap<std::string, shared_ptr<object> >& templates);
+                             umap<std::string, std::shared_ptr<object> >& templates);
     bool                   should_register() const throw ();
     object_type            type() const throw ();
     std::string const&     type_name() const throw ();
@@ -112,38 +111,12 @@ namespace                  configuration {
     object_type            _type;
   };
 
-  typedef shared_ptr<object>            object_ptr;
+  typedef std::shared_ptr<object>            object_ptr;
   typedef std::list<object_ptr>         list_object;
   typedef umap<std::string, object_ptr> map_object;
 }
 
 CCE_END()
-
-namespace std {
-  template <typename T>
-  struct  less<com::centreon::shared_ptr<T> >
-            : std::binary_function<
-                     com::centreon::shared_ptr<T>,
-                     com::centreon::shared_ptr<T>,
-                     bool> {
-    bool  operator()(
-            com::centreon::shared_ptr<T> const& left,
-            com::centreon::shared_ptr<T> const& right) const {
-      bool retval;
-      if (left.get()) {
-        if (right.get())
-          retval = *left < *right;
-        else
-          retval = false;
-      }
-      else if (right.get())
-        retval = true;
-      else
-        retval = false;
-      return (retval);
-    }
-  };
-}
 
 #  define MRG_TAB(prop) \
   do { \

--- a/neb/inc/com/centreon/engine/configuration/service.hh
+++ b/neb/inc/com/centreon/engine/configuration/service.hh
@@ -46,7 +46,7 @@ namespace                  configuration {
       flapping = (1 << 4),
       downtime = (1 << 5)
     };
-    typedef                std::pair<std::string, std::string>
+    typedef                std::pair<unsigned int, unsigned int>
                            key_type;
 
                            service();
@@ -204,7 +204,6 @@ namespace                  configuration {
     opt<unsigned int>      _high_flap_threshold;
     group<set_string>      _hostgroups;
     group<set_string>      _hosts;
-    unsigned int           _host_id;
     std::string            _icon_image;
     std::string            _icon_image_alt;
     opt<unsigned int>      _initial_state;

--- a/neb/inc/com/centreon/engine/configuration/service.hh
+++ b/neb/inc/com/centreon/engine/configuration/service.hh
@@ -230,9 +230,9 @@ namespace                  configuration {
     opt<std::string>       _timezone;
  };
 
-  typedef shared_ptr<service>    service_ptr;
-  typedef std::list<service_ptr> list_service;
-  typedef std::set<service>      set_service;
+  typedef std::shared_ptr<service> service_ptr;
+  typedef std::list<service_ptr>   list_service;
+  typedef std::set<service>        set_service;
   typedef umap<std::pair<std::string, std::string>, service_ptr> map_service;
 }
 

--- a/neb/inc/com/centreon/engine/configuration/servicedependency.hh
+++ b/neb/inc/com/centreon/engine/configuration/servicedependency.hh
@@ -128,8 +128,8 @@ namespace                  configuration {
     static setters const   _setters[];
   };
 
-  typedef shared_ptr<servicedependency>  servicedependency_ptr;
-  typedef std::set<servicedependency>    set_servicedependency;
+  typedef std::shared_ptr<servicedependency>  servicedependency_ptr;
+  typedef std::set<servicedependency>         set_servicedependency;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/configuration/serviceescalation.hh
+++ b/neb/inc/com/centreon/engine/configuration/serviceescalation.hh
@@ -120,8 +120,8 @@ namespace                  configuration {
     static setters const   _setters[];
   };
 
-  typedef shared_ptr<serviceescalation>  serviceescalation_ptr;
-  typedef std::set<serviceescalation>    set_serviceescalation;
+  typedef std::shared_ptr<serviceescalation>  serviceescalation_ptr;
+  typedef std::set<serviceescalation>         set_serviceescalation;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/configuration/servicegroup.hh
+++ b/neb/inc/com/centreon/engine/configuration/servicegroup.hh
@@ -88,8 +88,8 @@ namespace                   configuration {
     static setters const    _setters[];
   };
 
-  typedef shared_ptr<servicegroup>  servicegroup_ptr;
-  typedef std::set<servicegroup>    set_servicegroup;
+  typedef std::shared_ptr<servicegroup>  servicegroup_ptr;
+  typedef std::set<servicegroup>         set_servicegroup;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/configuration/state.hh
+++ b/neb/inc/com/centreon/engine/configuration/state.hh
@@ -40,7 +40,6 @@
 #  include "com/centreon/engine/logging/logger.hh"
 #  include "com/centreon/engine/namespace.hh"
 #  include "com/centreon/engine/string.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/configuration/state.hh
+++ b/neb/inc/com/centreon/engine/configuration/state.hh
@@ -238,6 +238,8 @@ namespace               configuration {
     set_host::const_iterator
                         hosts_find(host::key_type const& k) const;
     set_host::iterator  hosts_find(host::key_type const& k);
+    set_host::const_iterator
+                        hosts_find(std::string const& name) const;
     unsigned int        host_check_timeout() const throw ();
     void                host_check_timeout(unsigned int value);
     unsigned int        host_freshness_check_interval() const throw ();

--- a/neb/inc/com/centreon/engine/configuration/timeperiod.hh
+++ b/neb/inc/com/centreon/engine/configuration/timeperiod.hh
@@ -101,8 +101,8 @@ namespace                  configuration {
                            _timeranges;
   };
 
-  typedef shared_ptr<timeperiod> timeperiod_ptr;
-  typedef std::set<timeperiod>   set_timeperiod;
+  typedef std::shared_ptr<timeperiod> timeperiod_ptr;
+  typedef std::set<timeperiod>        set_timeperiod;
 }
 
 CCE_END()

--- a/neb/inc/com/centreon/engine/downtime_finder.hh
+++ b/neb/inc/com/centreon/engine/downtime_finder.hh
@@ -1,0 +1,62 @@
+/*
+** Copyright 2016 Centreon
+**
+** This file is part of Centreon Engine.
+**
+** Centreon Engine is free software: you can redistribute it and/or
+** modify it under the terms of the GNU General Public License version 2
+** as published by the Free Software Foundation.
+**
+** Centreon Engine is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Centreon Engine. If not, see
+** <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CCE_DOWNTIME_FINDER_HH
+#  define CCE_DOWNTIME_FINDER_HH
+
+#  include <string>
+#  include <vector>
+#  include "com/centreon/engine/namespace.hh"
+
+struct scheduled_downtime_struct;
+
+CCE_BEGIN()
+
+/**
+ *  @class downtime_finder downtime_finder.hh "com/centreon/engine/downtime_finder.hh"
+ *  @brier Find active downtimes.
+ *
+ *  This class can find active downtimes according to some criterias.
+ */
+class                 downtime_finder {
+public:
+  typedef std::pair<std::string, std::string>  criteria;
+  typedef std::vector<criteria>                criteria_set;
+  typedef std::vector<unsigned long>           result_set;
+
+                      downtime_finder(
+                        scheduled_downtime_struct const* list);
+                      downtime_finder(downtime_finder const& other);
+                      ~downtime_finder();
+  downtime_finder&    operator=(downtime_finder const& other);
+  result_set          find_matching_all(criteria_set const& criterias);
+  // result_set          find_matching_any(criteria_set const& criterias);
+
+private:
+  bool                _match_criteria(
+                        scheduled_downtime_struct const* dt,
+                        criteria const& crit);
+
+  scheduled_downtime_struct const*
+                      _list;
+};
+
+CCE_END()
+
+#endif // !CCE_DOWNTIME_FINDER_HH

--- a/neb/inc/com/centreon/engine/objects/host.hh
+++ b/neb/inc/com/centreon/engine/objects/host.hh
@@ -180,6 +180,7 @@ extern "C" {
 #  endif /* C++ */
 
 host* add_host(
+        unsigned int host_id,
         char const* name,
         char const* display_name,
         char const* alias,
@@ -263,9 +264,9 @@ std::ostream& operator<<(std::ostream& os, host const& obj);
 CCE_BEGIN()
 
 void          check_for_expired_acknowledgement(host* h);
-host&         find_host(std::string const& name);
+host&         find_host(unsigned int host_id);
 char const*   get_host_timezone(char const* name);
-bool          is_host_exist(std::string const& name) throw ();
+bool          is_host_exist(unsigned int host_id) throw ();
 unsigned int  get_host_id(char const* name);
 void          schedule_acknowledgement_expiration(host* h);
 

--- a/neb/inc/com/centreon/engine/objects/service.hh
+++ b/neb/inc/com/centreon/engine/objects/service.hh
@@ -164,6 +164,8 @@ extern "C" {
 #  endif /* C++ */
 
 service* add_service(
+           unsigned int host_id,
+           unsigned int service_id,
            char const* host_name,
            char const* description,
            char const* display_name,
@@ -240,11 +242,11 @@ CCE_BEGIN()
 
 void          check_for_expired_acknowledgement(service* s);
 service&      find_service(
-                std::string const& host_name,
-                std::string const& service_description);
+                unsigned int host_id,
+                unsigned int service_id);
 char const*   get_service_timezone(char const* hst, char const* svc);
 bool          is_service_exist(
-                std::pair<std::string, std::string> const& id);
+                std::pair<unsigned int, unsigned int> const& id);
 std::pair<unsigned int, unsigned int>
               get_host_and_service_id(
                 char const* host,

--- a/neb/inc/com/centreon/engine/retention/comment.hh
+++ b/neb/inc/com/centreon/engine/retention/comment.hh
@@ -24,7 +24,6 @@
 #  include <string>
 #  include "com/centreon/engine/namespace.hh"
 #  include "com/centreon/engine/retention/object.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/retention/contact.hh
+++ b/neb/inc/com/centreon/engine/retention/contact.hh
@@ -27,7 +27,6 @@
 #  include "com/centreon/engine/objects/customvariable.hh"
 #  include "com/centreon/engine/opt.hh"
 #  include "com/centreon/engine/retention/object.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/retention/downtime.hh
+++ b/neb/inc/com/centreon/engine/retention/downtime.hh
@@ -24,7 +24,6 @@
 #  include <string>
 #  include "com/centreon/engine/namespace.hh"
 #  include "com/centreon/engine/retention/object.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/retention/host.hh
+++ b/neb/inc/com/centreon/engine/retention/host.hh
@@ -62,6 +62,7 @@ namespace                         retention {
     opt<bool> const&              event_handler_enabled() const throw ();
     opt<bool> const&              flap_detection_enabled() const throw ();
     opt<bool> const&              has_been_checked() const throw ();
+    unsigned long                 host_id() const throw ();
     std::string const&            host_name() const throw ();
     opt<bool> const&              is_flapping() const throw ();
     opt<time_t> const&            last_acknowledgement() const throw ();
@@ -123,6 +124,7 @@ namespace                         retention {
     bool                          _set_failure_prediction_enabled(bool value);
     bool                          _set_flap_detection_enabled(bool value);
     bool                          _set_has_been_checked(bool value);
+    bool                          _set_host_id(unsigned long value);
     bool                          _set_host_name(std::string const& value);
     bool                          _set_is_flapping(bool value);
     bool                          _set_last_acknowledgement(time_t value);
@@ -178,6 +180,7 @@ namespace                         retention {
     opt<bool>                     _event_handler_enabled;
     opt<bool>                     _flap_detection_enabled;
     opt<bool>                     _has_been_checked;
+    unsigned long                 _host_id;
     std::string                   _host_name;
     opt<bool>                     _is_flapping;
     opt<time_t>                   _last_acknowledgement;

--- a/neb/inc/com/centreon/engine/retention/host.hh
+++ b/neb/inc/com/centreon/engine/retention/host.hh
@@ -27,7 +27,6 @@
 #  include "com/centreon/engine/objects/customvariable.hh"
 #  include "com/centreon/engine/opt.hh"
 #  include "com/centreon/engine/retention/object.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/retention/info.hh
+++ b/neb/inc/com/centreon/engine/retention/info.hh
@@ -24,7 +24,6 @@
 #  include <string>
 #  include "com/centreon/engine/namespace.hh"
 #  include "com/centreon/engine/retention/object.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/retention/object.hh
+++ b/neb/inc/com/centreon/engine/retention/object.hh
@@ -23,7 +23,6 @@
 #  include <string>
 #  include "com/centreon/engine/namespace.hh"
 #  include "com/centreon/engine/string.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/retention/program.hh
+++ b/neb/inc/com/centreon/engine/retention/program.hh
@@ -24,7 +24,6 @@
 #  include "com/centreon/engine/namespace.hh"
 #  include "com/centreon/engine/opt.hh"
 #  include "com/centreon/engine/retention/object.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/retention/service.hh
+++ b/neb/inc/com/centreon/engine/retention/service.hh
@@ -95,6 +95,7 @@ namespace                         retention {
     opt<bool> const&              problem_has_been_acknowledged() const throw ();
     opt<int> const&               process_performance_data() const throw ();
     opt<unsigned int> const&      retry_check_interval() const throw ();
+    unsigned long                 service_id() const throw ();
     std::string const&            service_description() const throw ();
     opt<std::vector<int> > const& state_history() const throw ();
     opt<int> const&               state_type() const throw ();
@@ -159,6 +160,7 @@ namespace                         retention {
     bool                          _set_problem_has_been_acknowledged(bool value);
     bool                          _set_process_performance_data(int value);
     bool                          _set_retry_check_interval(unsigned int value);
+    bool                          _set_service_id(unsigned long value);
     bool                          _set_service_description(std::string const& value);
     bool                          _set_state_history(std::string const& value);
     bool                          _set_state_type(int value);
@@ -219,6 +221,7 @@ namespace                         retention {
     opt<int>                      _process_performance_data;
     opt<bool>                     _recovery_been_sent;
     opt<unsigned int>             _retry_check_interval;
+    unsigned long                 _service_id;
     std::string                   _service_description;
     static setters const          _setters[];
     opt<std::vector<int> >        _state_history;

--- a/neb/inc/com/centreon/engine/retention/service.hh
+++ b/neb/inc/com/centreon/engine/retention/service.hh
@@ -27,7 +27,6 @@
 #  include "com/centreon/engine/objects/customvariable.hh"
 #  include "com/centreon/engine/opt.hh"
 #  include "com/centreon/engine/retention/object.hh"
-#  include "com/centreon/shared_ptr.hh"
 
 CCE_BEGIN()
 

--- a/neb/inc/com/centreon/engine/timeperiod.hh
+++ b/neb/inc/com/centreon/engine/timeperiod.hh
@@ -1,5 +1,6 @@
 /*
-** Copyright 2012-2013 Merethis
+** Copyright 1999-2009      Ethan Galstad
+** Copyright 2011-2014,2016 Centreon
 **
 ** This file is part of Centreon Engine.
 **
@@ -17,13 +18,23 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CCE_VERSION_HH
-#  define CCE_VERSION_HH
+#ifndef CCE_TIMEPERIOD_HH
+#  define CCE_TIMEPERIOD_HH
 
-// Compile-time values.
-#  define CENTREON_ENGINE_VERSION_MAJOR  19
-#  define CENTREON_ENGINE_VERSION_MINOR  10
-#  define CENTREON_ENGINE_VERSION_PATCH  0
-#  define CENTREON_ENGINE_VERSION_STRING "19.10.0"
+#  ifdef __cplusplus
+extern "C" {
+#  endif // C++
 
-#endif // !CCE_VERSION_HH
+int  check_time_against_period(
+       time_t test_time,
+       timeperiod* tperiod);
+void get_next_valid_time(
+       time_t pref_time,
+       time_t* valid_time,
+       timeperiod* tperiod);
+
+#  ifdef __cplusplus
+}
+#  endif // C++
+
+#endif // !CCE_TIMEPERIOD_HH

--- a/neb/test/node_events/downtime_fixed.cc
+++ b/neb/test/node_events/downtime_fixed.cc
@@ -25,7 +25,6 @@
 #include <QThread>
 #include "com/centreon/broker/config/applier/init.hh"
 #include "com/centreon/broker/extcmd/command_request.hh"
-#include "com/centreon/broker/misc/shared_ptr.hh"
 #include "com/centreon/broker/multiplexing/engine.hh"
 #include "com/centreon/broker/neb/node_events_stream.hh"
 #include "com/centreon/broker/neb/service_status.hh"

--- a/neb/test/node_events/downtime_floating.cc
+++ b/neb/test/node_events/downtime_floating.cc
@@ -25,7 +25,6 @@
 #include <QThread>
 #include "com/centreon/broker/config/applier/init.hh"
 #include "com/centreon/broker/extcmd/command_request.hh"
-#include "com/centreon/broker/misc/shared_ptr.hh"
 #include "com/centreon/broker/multiplexing/engine.hh"
 #include "com/centreon/broker/neb/node_events_stream.hh"
 #include "com/centreon/broker/neb/service_status.hh"

--- a/neb/test/node_events/file_downtime.cc
+++ b/neb/test/node_events/file_downtime.cc
@@ -28,7 +28,6 @@
 #include <QThread>
 #include "com/centreon/broker/config/applier/init.hh"
 #include "com/centreon/broker/misc/misc.hh"
-#include "com/centreon/broker/misc/shared_ptr.hh"
 #include "com/centreon/broker/multiplexing/engine.hh"
 #include "com/centreon/broker/neb/node_events_stream.hh"
 #include "com/centreon/broker/neb/service_status.hh"

--- a/neb/test/node_events/recurring_downtime.cc
+++ b/neb/test/node_events/recurring_downtime.cc
@@ -25,7 +25,6 @@
 #include <QThread>
 #include "com/centreon/broker/config/applier/init.hh"
 #include "com/centreon/broker/extcmd/command_request.hh"
-#include "com/centreon/broker/misc/shared_ptr.hh"
 #include "com/centreon/broker/multiplexing/engine.hh"
 #include "com/centreon/broker/multiplexing/muxer.hh"
 #include "com/centreon/broker/multiplexing/subscriber.hh"


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Add support for c++11 in engine.
use std::shared_ptr and std::unique_ptr.

<h2> Type of change </h2>

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> Checklist </h2>

I followed the **coding style guidelines** provided by Centreon
I have **rebased** my development branch on the base branch (master, maintenance).
I have made sure that the **unit tests** related to the story are successful.
