### PR TITLE
(fix) fix enum input with strict mode

### DIFF
--- a/storage/src/stream.cc
+++ b/storage/src/stream.cc
@@ -924,8 +924,8 @@ void stream::_insert_perfdatas() {
             << "INSERT INTO " << (db_v2 ? "data_bin" : "log_data_bin")
             << "  (" << (db_v2 ? "id_metric" : "metric_id")
             << "   , ctime, status, value)"
-               "  VALUES (" << mv.metric_id << ", " << mv.c_time << ", "
-            << mv.status << ", '";
+               "  VALUES (" << mv.metric_id << ", " << mv.c_time << ", '"
+            << mv.status << "', '";
       if (std::isinf(mv.value))
         query << ((mv.value < 0.0) ? -FLT_MAX : FLT_MAX);
       else if (std::isnan(mv.value))
@@ -939,8 +939,8 @@ void stream::_insert_perfdatas() {
     // Insert perfdata in data_bin.
     while (!_perfdata_queue.empty()) {
       metric_value& mv(_perfdata_queue.front());
-      query << ", (" << mv.metric_id << ", " << mv.c_time << ", "
-            << mv.status << ", ";
+      query << ", (" << mv.metric_id << ", " << mv.c_time << ", '"
+            << mv.status << "', ";
       if (std::isinf(mv.value))
         query << ((mv.value < 0.0) ? -FLT_MAX : FLT_MAX);
       else if (std::isnan(mv.value))


### PR DESCRIPTION
The `enum` type must be a string format because strict mode of MariaDB.

error output with strict mode enabled:
```
ERROR 1265: Data truncated for column 'status' at row 1 : INSERT INTO data_bin  (id_metric   , ctime, status, value)  VALUES (1, 1558007396, 0, '1.9687900000e+02')
```