### PR TITLE
enh(stats): fix a bug in the parser.

### DIFF
--- a/stats/test/stats.cc
+++ b/stats/test/stats.cc
@@ -290,11 +290,15 @@ TEST_F(StatsTest, CopyCtor) {
 TEST_F(StatsTest, Parser) {
   stats::parser parser;
   std::vector<std::string> result;
+  std::vector<std::string> result2;
 
   parser.parse(result, "{}");
   ASSERT_TRUE(result.size() == 0);
   parser.parse(result, "{ \"json_fifo\":\"/tmp/test.txt\" }");
   ASSERT_TRUE(result.size() == 1);
+  ASSERT_TRUE(result2.size() == 0);
+  parser.parse(result2, "[{ \"json_fifo\":\"/tmp/test.txt\" }]");
+  ASSERT_TRUE(result2.size() == 1);
 
   ASSERT_THROW(parser.parse(result, "ds{ahsjklhdasjhdaskjh"), exceptions::msg);
 }


### PR DESCRIPTION
The parser was waiting for an json:object {json_fifo: ...}
but sometime it can take an array of json:object like
[{json_fifo: ...}]