### PR TITLE
enh(bbdo): uint64_t are not supported yet by BBDO.

### DIFF
--- a/bam/inc/com/centreon/broker/bam/dimension_kpi_event.hh
+++ b/bam/inc/com/centreon/broker/bam/dimension_kpi_event.hh
@@ -48,9 +48,9 @@ class dimension_kpi_event : public io::data {
   unsigned kpi_id;
   unsigned int ba_id;
   std::string ba_name;
-  uint64_t host_id;
+  uint32_t host_id;
   std::string host_name;
-  uint64_t service_id;
+  uint32_t service_id;
   std::string service_description;
   unsigned int kpi_ba_id;
   std::string kpi_ba_name;

--- a/core/inc/com/centreon/broker/mapping/property.hh
+++ b/core/inc/com/centreon/broker/mapping/property.hh
@@ -144,18 +144,6 @@ class property : public source {
   }
 
   /**
-   *  Unsigned long integer constructor.
-   *
-   *  @param[in]  l Unsigned long integer property.
-   *  @param[out] t If not NULL, set to ULONG.
-   */
-  property(uint64_t(T::*l), source_type* t) {
-    _prop.l = l;
-    if (t)
-      *t = ULONG;
-  }
-
-  /**
    *  Copy constructor.
    *
    *  @param[in] other Object to copy.

--- a/graphite/src/query.cc
+++ b/graphite/src/query.cc
@@ -193,7 +193,7 @@ void query::_compile_naming_scheme(std::string const& naming_scheme,
     if (macro == "$METRICID$") {
       _throw_on_invalid(metric);
       _compiled_getters.push_back(
-          &query::_get_member<uint64_t, storage::metric,
+          &query::_get_member<uint32_t, storage::metric,
                               &storage::metric::metric_id>);
     } else if (macro == "$INSTANCE$")
       _compiled_getters.push_back(&query::_get_instance);

--- a/influxdb/src/line_protocol_query.cc
+++ b/influxdb/src/line_protocol_query.cc
@@ -312,7 +312,7 @@ void line_protocol_query::_compile_scheme(
     if (macro == "$METRICID$") {
       _throw_on_invalid(metric);
       _append_compiled_getter(
-          &line_protocol_query::_get_member<uint64_t, storage::metric,
+          &line_protocol_query::_get_member<uint32_t , storage::metric,
                                             &storage::metric::metric_id>,
           escaper);
     } else if (macro == "$INSTANCE$")

--- a/storage/inc/com/centreon/broker/storage/metric.hh
+++ b/storage/inc/com/centreon/broker/storage/metric.hh
@@ -58,13 +58,13 @@ class metric : public io::data {
   timestamp ctime;
   unsigned int interval;
   bool is_for_rebuild;
-  uint64_t metric_id;
+  uint32_t metric_id;
   std::string name;
   int rrd_len;
   double value;
   short value_type;
-  uint64_t host_id;
-  uint64_t service_id;
+  uint32_t host_id;
+  uint32_t service_id;
 
   static mapping::entry const entries[];
   static io::event_info::event_operations const operations;


### PR DESCRIPTION
Revert support of uint64_t in property.hh, this change needs an update of BBDO.
We are too far away in the release cycle to put this change.