### PR TITLE
enh(sql): reduce max timestamp to match integer value

### DIFF
--- a/bam/src/monitoring_stream.cc
+++ b/bam/src/monitoring_stream.cc
@@ -373,18 +373,17 @@ int monitoring_stream::write(std::shared_ptr<io::data> const& data) {
   else if (data->type() == inherited_downtime::static_type()) {
     std::ostringstream oss;
     timestamp now = timestamp::now();
-    timestamp max_timestamp = std::numeric_limits<int32_t>::max();
     inherited_downtime const& dwn = *std::static_pointer_cast<inherited_downtime const>(data);
     if (dwn.in_downtime)
       oss << "[" << now << "] SCHEDULE_SVC_DOWNTIME;_Module_BAM_"
           << config::applier::state::instance().poller_id() << ";ba_"
-          << dwn.ba_id << ";" << now << ";" << max_timestamp
+          << dwn.ba_id << ";" << now << ";" << std::numeric_limits<int32_t>::max()
           << ";1;0;0;Centreon Broker BAM Module;"
              "Automatic downtime triggered by BA downtime inheritance";
     else
       oss << "[" << now << "] DEL_SVC_DOWNTIME_FULL;_Module_BAM_"
           << config::applier::state::instance().poller_id() << ";ba_"
-          << dwn.ba_id << ";;" << max_timestamp
+          << dwn.ba_id << ";;" << std::numeric_limits<int32_t>::max()
           << ";1;0;;Centreon Broker BAM Module;"
              "Automatic downtime triggered by BA downtime inheritance";
     _write_external_command(oss.str());

--- a/bam/src/monitoring_stream.cc
+++ b/bam/src/monitoring_stream.cc
@@ -18,6 +18,7 @@
 
 #include <cstdlib>
 #include <ctime>
+#include <limits>
 #include <fstream>
 #include <sstream>
 #include <QMutexLocker>
@@ -372,17 +373,18 @@ int monitoring_stream::write(std::shared_ptr<io::data> const& data) {
   else if (data->type() == inherited_downtime::static_type()) {
     std::ostringstream oss;
     timestamp now = timestamp::now();
+    timestamp max_timestamp = std::numeric_limits<int32_t>::max();
     inherited_downtime const& dwn = *std::static_pointer_cast<inherited_downtime const>(data);
     if (dwn.in_downtime)
       oss << "[" << now << "] SCHEDULE_SVC_DOWNTIME;_Module_BAM_"
           << config::applier::state::instance().poller_id() << ";ba_"
-          << dwn.ba_id << ";" << now << ";" << timestamp::max()
+          << dwn.ba_id << ";" << now << ";" << max_timestamp
           << ";1;0;0;Centreon Broker BAM Module;"
              "Automatic downtime triggered by BA downtime inheritance";
     else
       oss << "[" << now << "] DEL_SVC_DOWNTIME_FULL;_Module_BAM_"
           << config::applier::state::instance().poller_id() << ";ba_"
-          << dwn.ba_id << ";;" << timestamp::max()
+          << dwn.ba_id << ";;" << max_timestamp
           << ";1;0;;Centreon Broker BAM Module;"
              "Automatic downtime triggered by BA downtime inheritance";
     _write_external_command(oss.str());

--- a/bam/src/monitoring_stream.cc
+++ b/bam/src/monitoring_stream.cc
@@ -18,8 +18,8 @@
 
 #include <cstdlib>
 #include <ctime>
-#include <limits>
 #include <fstream>
+#include <limits>
 #include <sstream>
 #include <QMutexLocker>
 #include "com/centreon/broker/bam/ba_status.hh"

--- a/core/inc/com/centreon/broker/timestamp.hh
+++ b/core/inc/com/centreon/broker/timestamp.hh
@@ -137,10 +137,10 @@ public:
   /**
    *  Return the upper time limit.
    *
-   *  @return A timestamp set in a very far future (Tue Jan 19 04:14:07 CET 2038).
+   *  @return A timestamp set in a very far future.
    */
   static timestamp max() {
-    return (timestamp(std::numeric_limits<std::int32_t>::max()));
+    return (timestamp(std::numeric_limits<std::time_t>::max()));
   }
 
   // Data.

--- a/core/inc/com/centreon/broker/timestamp.hh
+++ b/core/inc/com/centreon/broker/timestamp.hh
@@ -140,7 +140,7 @@ public:
    *  @return A timestamp set in a very far future.
    */
   static timestamp max() {
-    return (timestamp(std::numeric_limits<std::time_t>::max()));
+    return (timestamp(std::numeric_limits<time_t>::max()));
   }
 
   // Data.

--- a/core/inc/com/centreon/broker/timestamp.hh
+++ b/core/inc/com/centreon/broker/timestamp.hh
@@ -137,10 +137,10 @@ public:
   /**
    *  Return the upper time limit.
    *
-   *  @return A timestamp set in a very far future.
+   *  @return A timestamp set in a very far future (Tue Jan 19 04:14:07 CET 2038).
    */
   static timestamp max() {
-    return (timestamp(std::numeric_limits<time_t>::max()));
+    return (timestamp(INT_MAX));
   }
 
   // Data.

--- a/core/inc/com/centreon/broker/timestamp.hh
+++ b/core/inc/com/centreon/broker/timestamp.hh
@@ -140,7 +140,7 @@ public:
    *  @return A timestamp set in a very far future (Tue Jan 19 04:14:07 CET 2038).
    */
   static timestamp max() {
-    return (timestamp(INT_MAX));
+    return (timestamp(std::numeric_limits<std::int32_t>::max()));
   }
 
   // Data.


### PR DESCRIPTION
Avoid to update downtime.end_time and downtime.duration to bigint columns

Refs: BAM-750