### PR TITLE
enh(log): add a log entry for all kind of event_handler

### DIFF
--- a/doc/release_notes/broker20.04.rst
+++ b/doc/release_notes/broker20.04.rst
@@ -1,0 +1,30 @@
+=======================
+Centreon Broker 20.04
+=======================
+
+************
+Enhancements
+************
+
+Removal of Qt
+=============
+Broker does not need Qt anymore.
+
+JSon
+=====
+Switch from Xml config to Json. We used json11 toolkit, and remove
+all ref for yajl from sources.
+
+Network
+========
+Switch from QtNetwork to Asio. We start an effort to avoir copy in network
+buffers.
+
+Optimization
+============
+Migration of the code to C++11.
+
+Better test Coverage
+====================
+We now have 370+ tests (+280%). It allow us to have a better code coverage
+of the code base.

--- a/doc/release_notes/index.rst
+++ b/doc/release_notes/index.rst
@@ -5,6 +5,7 @@ Release notes
 .. toctree::
    :glob:
 
+   broker20.04
    broker19.10
    broker18.10
    broker30

--- a/neb/inc/com/centreon/broker/neb/log_entry.hh
+++ b/neb/inc/com/centreon/broker/neb/log_entry.hh
@@ -40,6 +40,23 @@ namespace neb {
  */
 class log_entry : public io::data {
  public:
+  typedef enum {
+    service_alert = 0,
+    host_alert = 1,
+    service_notification = 2,
+    host_notification = 3,
+    warning = 4,
+    other = 5,
+    service_initial_state = 8,
+    host_initial_state = 9,
+    service_acknowledge_problem = 10,
+    host_acknowledge_problem = 11,
+    service_event_handler = 12,
+    host_event_handler = 13,
+    global_service_event_handler = 14,
+    global_host_event_handler = 15,
+  } log_msg_type;
+
   log_entry();
   log_entry(log_entry const& other);
   ~log_entry();

--- a/neb/src/callbacks.cc
+++ b/neb/src/callbacks.cc
@@ -1439,8 +1439,7 @@ int neb::callback_log(int callback_type, void* data) {
     le->c_time = log_data->entry_time;
     le->poller_name = config::applier::state::instance().poller_name();
     if (log_data->data) {
-      if (log_data->data)
-        le->output = log_data->data;
+      le->output = log_data->data;
       set_log_data(*le, log_data->data);
     }
 

--- a/neb/src/set_log_data.cc
+++ b/neb/src/set_log_data.cc
@@ -113,7 +113,7 @@ void neb::set_log_data(neb::log_entry& le, char const* log_data) {
       lasts = lasts + 1 + strspn(lasts + 1, " ");
     }
     if (!strcmp(datadup, "SERVICE ALERT")) {
-      le.msg_type = 0;
+      le.msg_type = log_entry::service_alert;
       le.host_name = log_extract_first(lasts, &lasts);
       le.service_description = log_extract(&lasts);
       le.status = status_id(log_extract(&lasts));
@@ -121,14 +121,14 @@ void neb::set_log_data(neb::log_entry& le, char const* log_data) {
       le.retry = strtol(log_extract(&lasts), nullptr, 10);
       le.output = log_extract(&lasts);
     } else if (!strcmp(datadup, "HOST ALERT")) {
-      le.msg_type = 1;
+      le.msg_type = log_entry::host_alert;
       le.host_name = log_extract_first(lasts, &lasts);
       le.status = status_id(log_extract(&lasts));
       le.log_type = type_id(log_extract(&lasts));
       le.retry = strtol(log_extract(&lasts), nullptr, 10);
       le.output = log_extract(&lasts);
     } else if (!strcmp(datadup, "SERVICE NOTIFICATION")) {
-      le.msg_type = 2;
+      le.msg_type = log_entry::service_notification;
       le.notification_contact = log_extract_first(lasts, &lasts);
       le.host_name = log_extract(&lasts);
       le.service_description = log_extract(&lasts);
@@ -136,21 +136,21 @@ void neb::set_log_data(neb::log_entry& le, char const* log_data) {
       le.notification_cmd = log_extract(&lasts);
       le.output = log_extract(&lasts);
     } else if (!strcmp(datadup, "HOST NOTIFICATION")) {
-      le.msg_type = 3;
+      le.msg_type = log_entry::host_notification;
       le.notification_contact = log_extract_first(lasts, &lasts);
       le.host_name = log_extract(&lasts);
       le.status = notification_status_id(log_extract(&lasts));
       le.notification_cmd = log_extract(&lasts);
       le.output = log_extract(&lasts);
     } else if (!strcmp(datadup, "INITIAL HOST STATE")) {
-      le.msg_type = 9;
+      le.msg_type = log_entry::host_initial_state;
       le.host_name = log_extract_first(lasts, &lasts);
       le.status = status_id(log_extract(&lasts));
       le.log_type = type_id(log_extract(&lasts));
       le.retry = strtol(log_extract(&lasts), nullptr, 10);
       le.output = log_extract(&lasts);
     } else if (!strcmp(datadup, "INITIAL SERVICE STATE")) {
-      le.msg_type = 8;
+      le.msg_type = log_entry::service_initial_state;
       le.host_name = log_extract_first(lasts, &lasts);
       le.service_description = log_extract(&lasts);
       le.status = status_id(log_extract(&lasts));
@@ -160,7 +160,7 @@ void neb::set_log_data(neb::log_entry& le, char const* log_data) {
     } else if (!strcmp(datadup, "EXTERNAL COMMAND")) {
       char* data(log_extract_first(lasts, &lasts));
       if (!strcmp(data, "ACKNOWLEDGE_SVC_PROBLEM")) {
-        le.msg_type = 10;
+        le.msg_type = log_entry::service_acknowledge_problem;
         le.host_name = log_extract(&lasts);
         le.service_description = log_extract(&lasts);
         log_extract(&lasts);
@@ -169,7 +169,7 @@ void neb::set_log_data(neb::log_entry& le, char const* log_data) {
         le.notification_contact = log_extract(&lasts);
         le.output = log_extract(&lasts);
       } else if (!strcmp(data, "ACKNOWLEDGE_HOST_PROBLEM")) {
-        le.msg_type = 11;
+        le.msg_type = log_entry::host_acknowledge_problem;
         le.host_name = log_extract(&lasts);
         log_extract(&lasts);
         log_extract(&lasts);
@@ -177,14 +177,44 @@ void neb::set_log_data(neb::log_entry& le, char const* log_data) {
         le.notification_contact = log_extract(&lasts);
         le.output = log_extract(&lasts);
       } else {
-        le.msg_type = 5;
+        le.msg_type = log_entry::other;
         le.output = log_data;
       }
+    }  else if (!strcmp(datadup, "HOST EVENT HANDLER")) {
+      le.msg_type = log_entry::host_event_handler;
+      le.host_name = log_extract_first(lasts, &lasts);
+      le.status = status_id(log_extract(&lasts));
+      le.log_type = type_id(log_extract(&lasts));
+      le.retry = strtol(log_extract(&lasts), nullptr, 10);
+      le.output = log_extract(&lasts);
+    } else if (!strcmp(datadup, "SERVICE EVENT HANDLER")) {
+      le.msg_type = log_entry::service_event_handler;
+      le.host_name = log_extract_first(lasts, &lasts);
+      le.service_description = log_extract(&lasts);
+      le.status = status_id(log_extract(&lasts));
+      le.log_type = type_id(log_extract(&lasts));
+      le.retry = strtol(log_extract(&lasts), nullptr, 10);
+      le.output = log_extract(&lasts);
+    } else if (!strcmp(datadup, "GLOBAL HOST EVENT HANDLER")) {
+      le.msg_type = log_entry::global_host_event_handler;
+      le.host_name = log_extract_first(lasts, &lasts);
+      le.status = status_id(log_extract(&lasts));
+      le.log_type = type_id(log_extract(&lasts));
+      le.retry = strtol(log_extract(&lasts), nullptr, 10);
+      le.output = log_extract(&lasts);
+    } else if (!strcmp(datadup, "GLOBAL SERVICE EVENT HANDLER")) {
+      le.msg_type = log_entry::global_service_event_handler;
+      le.host_name = log_extract_first(lasts, &lasts);
+      le.service_description = log_extract(&lasts);
+      le.status = status_id(log_extract(&lasts));
+      le.log_type = type_id(log_extract(&lasts));
+      le.retry = strtol(log_extract(&lasts), nullptr, 10);
+      le.output = log_extract(&lasts);
     } else if (!strcmp(datadup, "Warning")) {
-      le.msg_type = 4;
+      le.msg_type = log_entry::warning;
       le.output = lasts;
     } else {
-      le.msg_type = 5;
+      le.msg_type = log_entry::other;
       le.output = log_data;
     }
   } catch (...) {

--- a/neb/test/set_log_data.cc
+++ b/neb/test/set_log_data.cc
@@ -155,3 +155,84 @@ TEST(SetLogData, ServiceALert) {
   ASSERT_FALSE(le.service_description != "myservice");
   ASSERT_FALSE(le.status != 1);
 }
+
+/**
+ *  Check that a service alert log is properly parsed.
+ */
+TEST(SetLogData, HostEventHandler) {
+  // Log entry.
+  neb::log_entry le;
+
+  // Parse a service alert line.
+  neb::set_log_data(le, "HOST EVENT HANDLER: myserver;WARNING;SOFT;3;coucou");
+
+  // Check that it was properly parsed.
+  ASSERT_FALSE(le.host_name != "myserver");
+  ASSERT_FALSE(le.log_type != 0);
+  ASSERT_FALSE(le.msg_type != neb::log_entry::host_event_handler);
+  ASSERT_FALSE(le.output != "coucou");
+  ASSERT_FALSE(le.retry != 3);
+  ASSERT_FALSE(le.status != 1);
+}
+
+/**
+ *  Check that a service alert log is properly parsed.
+ */
+TEST(SetLogData, ServiceEventHandler) {
+  // Log entry.
+  neb::log_entry le;
+
+  // Parse a service alert line.
+  neb::set_log_data(
+      le, "SERVICE EVENT HANDLER: myserver;myservice;WARNING;SOFT;3;coucou");
+
+  // Check that it was properly parsed.
+  ASSERT_FALSE(le.host_name != "myserver");
+  ASSERT_FALSE(le.log_type != 0);
+  ASSERT_FALSE(le.msg_type != neb::log_entry::service_event_handler);
+  ASSERT_FALSE(le.output != "coucou");
+  ASSERT_FALSE(le.retry != 3);
+  ASSERT_FALSE(le.service_description != "myservice");
+  ASSERT_FALSE(le.status != 1);
+}
+
+/**
+ *  Check that a service alert log is properly parsed.
+ */
+TEST(SetLogData, GlobalHostEventHandler) {
+  // Log entry.
+  neb::log_entry le;
+
+  // Parse a service alert line.
+  neb::set_log_data(
+      le, "GLOBAL HOST EVENT HANDLER: myserver;WARNING;SOFT;3;coucou");
+
+  // Check that it was properly parsed.
+  ASSERT_FALSE(le.host_name != "myserver");
+  ASSERT_FALSE(le.log_type != 0);
+  ASSERT_FALSE(le.msg_type != neb::log_entry::global_host_event_handler);
+  ASSERT_FALSE(le.output != "coucou");
+  ASSERT_FALSE(le.retry != 3);
+  ASSERT_FALSE(le.status != 1);
+}
+
+/**
+ *  Check that a service alert log is properly parsed.
+ */
+TEST(SetLogData, GlobalServiceEventHandler) {
+  // Log entry.
+  neb::log_entry le;
+
+  // Parse a service alert line.
+  neb::set_log_data(
+      le, "GLOBAL SERVICE EVENT HANDLER: myserver;myservice;WARNING;SOFT;3;coucou");
+
+  // Check that it was properly parsed.
+  ASSERT_FALSE(le.host_name != "myserver");
+  ASSERT_FALSE(le.log_type != 0);
+  ASSERT_FALSE(le.msg_type != neb::log_entry::global_service_event_handler);
+  ASSERT_FALSE(le.output != "coucou");
+  ASSERT_FALSE(le.retry != 3);
+  ASSERT_FALSE(le.service_description != "myservice");
+  ASSERT_FALSE(le.status != 1);
+}


### PR DESCRIPTION
Add a log entry for all kind of event_handler.

By now broker will do what it is needed to log event_handler in the centreon-web page :  "Monitoring > Event Logs > Event Logs"