### PR TITLE
fix(watchdog): if a sigkill is sent, watchdog wait for it now

### DIFF
--- a/watchdog/src/instance.cc
+++ b/watchdog/src/instance.cc
@@ -136,13 +136,19 @@ void instance::stop() {
           << _config.get_name() << "' (PID " << _pid << "):" << strerror(errno)
           << '\n';
     int status;
-    int timeout = 10;
+    int timeout = 30;
     while ((res = waitpid(_pid, &status, WNOHANG))) {
       if (--timeout < 0) {
         logging::error(logging::medium)
             << "watchdog: could not gracefully terminate process '"
             << _config.get_name() << "' (PID " << _pid << "): killing it";
         kill(_pid, SIGKILL);
+        res = waitpid(_pid, &status, 0);
+        if (res < 0) {
+          logging::error(logging::medium)
+              << "watchdog: Unable to kill the process '"
+              << _config.get_name() << "' (PID " << _pid << ")";
+        }
         return;
       }
       sleep(1);

--- a/watchdog/src/main.cc
+++ b/watchdog/src/main.cc
@@ -244,6 +244,7 @@ int main(int argc, char** argv) {
               << e.what();
         }
         sighup = false;
+        continue;
       }
 
       /* Let's wait a little */


### PR DESCRIPTION
# Pull Request Template

## Description

The watchdog waits a longer time before killing the process.
And when it must kill the process, it waits for its dead.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

With a centreon broker running. Enter the following command to get the cbd pid running :+1: 
`ps ax | grep cbd`

 Open the the /etc/centreon-broker/watchdog.json and change the name of one of the broker instances, for example we can choose successively the following names "central-rrd-master", "central-rrd-master1", "central-rrd-master2", ...

Each time the name is changed, execute as root the command 'systemctl reload cbd'.
When the command is finished, verify that there is always two cbd instances, the one whose name did not change has the same pid and the other has a new pid. To verify this, enter the following command:
`ps ax | grep cbd`

If sometimes, you have more or less than 2 cbd instances (do not take in acount the <defunc> processes), you have a bug...

Before the check, wait for the systemctl command to finish!
