### PR TITLE
Do not thow exception on tcp::acceptor::listen_on

### DIFF
--- a/core/test/test_server.cc
+++ b/core/test/test_server.cc
@@ -30,11 +30,11 @@ static uint32_t const timeout_ms = 5;
 static uint32_t const buff_size = 1024;
 
 test_server::test_server()
-    : _ctx{nullptr},
+    : _initialised{false},
+      _ctx{nullptr},
       _acceptor{nullptr},
       _connections{},
       _num_connections{0},
-      _initialised{false},
       _bind_ok{false} {
   _answer_reply.insert({"PING\n", "PONG\n"});
   _answer_reply.insert(

--- a/core/test/test_server.hh
+++ b/core/test/test_server.hh
@@ -72,7 +72,6 @@ class test_server {
   std::unique_ptr<asio::ip::tcp::acceptor> _acceptor;
   std::list<test_server_connection> _connections;
   std::atomic_size_t _num_connections;
-  std::atomic_bool _init_done;
   std::atomic_bool _bind_ok;
   std::unordered_map<std::string, std::string> _answer_reply;
 };

--- a/neb/test/custom_variable.cc
+++ b/neb/test/custom_variable.cc
@@ -79,7 +79,7 @@ TEST_F(CVarTest, CopyConstructor) {
 TEST_F(CVarTest, DefaultConstructor) {
   // Object.
   neb::custom_variable cvar;
-
+  io::data::broker_id = 0;
   // Check.
   ASSERT_EQ(cvar.source_id, 0u);
   ASSERT_EQ(cvar.destination_id, 0u);

--- a/neb/test/custom_variable_status.cc
+++ b/neb/test/custom_variable_status.cc
@@ -79,7 +79,7 @@ TEST_F(CVarStatusTest, CopyConstructor) {
 TEST_F(CVarStatusTest, DefaultConstructor) {
   // Object.
   neb::custom_variable_status cvar_status;
-
+  io::data::broker_id = 0;
   // Check.
   ASSERT_EQ(cvar_status.source_id, 0u);
   ASSERT_EQ(cvar_status.destination_id, 0u);

--- a/neb/test/event_handler.cc
+++ b/neb/test/event_handler.cc
@@ -80,7 +80,7 @@ TEST_F(EventHandlerTest, CopyConstructor) {
 TEST_F(EventHandlerTest, DefaultConstructor) {
   // Object.
   neb::event_handler evnt_hndlr;
-
+  io::data::broker_id = 0;
   // Check.
   ASSERT_EQ(evnt_hndlr.source_id, 0u);
   ASSERT_EQ(evnt_hndlr.destination_id, 0u);

--- a/neb/test/flapping_status.cc
+++ b/neb/test/flapping_status.cc
@@ -80,7 +80,7 @@ TEST_F(FlappingStatus, CopyConstructor) {
 TEST_F(FlappingStatus, DefaultConstructor) {
   // Object.
   neb::flapping_status flappy;
-
+  io::data::broker_id = 0;
   // Check.
   ASSERT_EQ(flappy.source_id, 0u);
   ASSERT_EQ(flappy.destination_id, 0u);

--- a/neb/test/host.cc
+++ b/neb/test/host.cc
@@ -79,6 +79,7 @@ TEST_F(HostTest, CopyConstructor) {
 
 TEST_F(HostTest, DefaultConstructor) {
   // Object.
+  io::data::broker_id = 0;
   neb::host h;
 
   // Check.

--- a/tcp/inc/com/centreon/broker/tcp/acceptor.hh
+++ b/tcp/inc/com/centreon/broker/tcp/acceptor.hh
@@ -56,8 +56,10 @@ class acceptor : public io::endpoint {
   std::mutex _childrenm;
   std::mutex _mutex;
   unsigned short _port;
+  bool _binding;
   int _read_timeout;
   int _write_timeout;
+  asio::ip::tcp::endpoint _ep;
   std::unique_ptr<asio::ip::tcp::acceptor> _acceptor;
 };
 }  // namespace tcp

--- a/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
+++ b/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
@@ -41,7 +41,7 @@ struct tcp_con {
   // waiting for data
   std::condition_variable _wait_socket_event;
 
-  tcp_con() : _closing{false}, _timeout{false}, _timer{nullptr} {};
+  tcp_con() : _timer{nullptr}, _closing{false}, _timeout{false} {};
 };
 
 class tcp_async {

--- a/tcp/src/connector.cc
+++ b/tcp/src/connector.cc
@@ -64,12 +64,11 @@ std::shared_ptr<io::stream> connector::open() {
       << "TCP: connecting to " << _host << ":" << _port;
   std::string connection_name{_host + ":" + std::to_string(_port)};
 
-  std::shared_ptr<asio::ip::tcp::socket> sock =
-      std::make_shared<asio::ip::tcp::socket>(
-          tcp_async::instance().get_io_ctx());
-  asio::ip::tcp::resolver resolver{tcp_async::instance().get_io_ctx()};
-  asio::ip::tcp::resolver::query query{_host, std::to_string(_port)};
+  std::shared_ptr<asio::ip::tcp::socket> sock;
   try {
+    sock.reset(new asio::ip::tcp::socket(tcp_async::instance().get_io_ctx()));
+    asio::ip::tcp::resolver resolver{tcp_async::instance().get_io_ctx()};
+    asio::ip::tcp::resolver::query query{_host, std::to_string(_port)};
     asio::ip::tcp::resolver::iterator it{resolver.resolve(query)};
     asio::ip::tcp::resolver::iterator end;
 

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -195,7 +195,7 @@ void tcp_async::_async_job() {
   }
 }
 
-tcp_async::tcp_async() : _closed{false}, _strand{_io_context} {
+tcp_async::tcp_async() : _strand{_io_context}, _closed{false} {
   _async_thread = std::thread(&tcp_async::_async_job, this);
 }
 


### PR DESCRIPTION
Do not thow exception on tcp::acceptor::listen_on. When we try to bind on a unavailable port, broker was exiting without whining....

