### PR TITLE
feat(bam): add a new downtime mechanism => ignore_kpi

### DIFF
--- a/bam/inc/com/centreon/broker/bam/ba.hh
+++ b/bam/inc/com/centreon/broker/bam/ba.hh
@@ -51,15 +51,15 @@ class ba : public computable, public service_listener {
  public:
   typedef impact_values::state state;
 
- private:
-  static int const _recompute_limit = 100;
-
   struct impact_info {
     std::shared_ptr<kpi> kpi_ptr;
     impact_values hard_impact;
     impact_values soft_impact;
     bool in_downtime;
   };
+
+ private:
+  static int const _recompute_limit = 100;
 
   void _apply_impact(kpi* kpi_ptr, impact_info& impact);
   void _open_new_event(io::stream* visitor, short service_hard_state);
@@ -91,7 +91,7 @@ class ba : public computable, public service_listener {
   int _recompute_count;
   uint32_t _service_id;
   bool _valid;
-  bool _inherit_kpi_downtime;
+  configuration::ba::downtime_behaviour _dt_behaviour;
   std::unique_ptr<inherited_downtime> _inherited_downtime;
 
   void _commit_initial_events(io::stream* visitor);
@@ -130,7 +130,7 @@ class ba : public computable, public service_listener {
   void set_initial_event(ba_event const& event);
   void set_name(std::string const& name);
   void set_valid(bool valid);
-  void set_inherit_kpi_downtime(bool value);
+  void set_downtime_behaviour(configuration::ba::downtime_behaviour value);
   void set_state_source(configuration::ba::state_source source);
   void visit(io::stream* visitor);
   void service_update(std::shared_ptr<neb::downtime> const& dt,

--- a/bam/inc/com/centreon/broker/bam/configuration/ba.hh
+++ b/bam/inc/com/centreon/broker/bam/configuration/ba.hh
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <vector>
+
 #include "com/centreon/broker/bam/ba_event.hh"
 #include "com/centreon/broker/namespace.hh"
 
@@ -43,7 +44,9 @@ class ba {
     state_source_worst,
     state_source_ratio_percent,
     state_source_ratio_number
-  }state_source;
+  } state_source;
+
+  typedef enum { dt_ignore = 0, dt_inherit, dt_ignore_kpi } downtime_behaviour;
 
  private:
   uint32_t _id;
@@ -54,7 +57,7 @@ class ba {
   double _warning_level;
   double _critical_level;
   bam::ba_event _event;
-  bool _inherit_kpi_downtime;
+  downtime_behaviour _dt_behaviour;
 
  public:
   ba(uint32_t id = 0,
@@ -62,7 +65,7 @@ class ba {
      ba::state_source source = state_source_impact,
      double warning_level = 0.0,
      double critical_level = 0.0,
-     bool inherit_kpi_downtime = false);
+     downtime_behaviour dt_behaviour = dt_ignore);
   ba(ba const& right);
   ~ba();
   ba& operator=(ba const& right);
@@ -79,7 +82,7 @@ class ba {
   bam::ba_event const& get_opened_event() const;
   uint32_t get_default_timeperiod() const;
   std::vector<uint32_t> const& get_timeperiods() const;
-  bool get_inherit_kpi_downtime() const;
+  downtime_behaviour get_downtime_behaviour() const;
 
   void set_id(uint32_t id);
   void set_host_id(uint32_t host_id);
@@ -89,7 +92,7 @@ class ba {
   void set_warning_level(double warning_level);
   void set_critical_level(double critical_level);
   void set_opened_event(bam::ba_event const& e);
-  void set_inherit_kpi_downtime(bool value);
+  void set_downtime_behaviour(downtime_behaviour value);
 };
 }  // namespace configuration
 }  // namespace bam

--- a/bam/src/configuration/applier/ba.cc
+++ b/bam/src/configuration/applier/ba.cc
@@ -269,7 +269,7 @@ std::shared_ptr<bam::ba> applier::ba::_new_ba(configuration::ba const& cfg,
   obj->set_state_source(cfg.get_state_source());
   obj->set_level_warning(cfg.get_warning_level());
   obj->set_level_critical(cfg.get_critical_level());
-  obj->set_inherit_kpi_downtime(cfg.get_inherit_kpi_downtime());
+  obj->set_downtime_behaviour(cfg.get_downtime_behaviour());
   if (cfg.get_opened_event().ba_id)
     obj->set_initial_event(cfg.get_opened_event());
   book.listen(cfg.get_host_id(), cfg.get_service_id(), obj.get());

--- a/bam/src/configuration/ba.cc
+++ b/bam/src/configuration/ba.cc
@@ -35,7 +35,7 @@ ba::ba(uint32_t id,
        ba::state_source source,
        double warning_level,
        double critical_level,
-       bool inherit_kpi_downtime)
+       downtime_behaviour dt_behaviour)
     : _id(id),
       _host_id(0),
       _service_id(0),
@@ -43,7 +43,7 @@ ba::ba(uint32_t id,
       _state_source(source),
       _warning_level(warning_level),
       _critical_level(critical_level),
-      _inherit_kpi_downtime(inherit_kpi_downtime) {}
+      _dt_behaviour(dt_behaviour) {}
 
 /**
  *  Copy constructor.
@@ -59,7 +59,7 @@ ba::ba(ba const& other)
       _warning_level(other._warning_level),
       _critical_level(other._critical_level),
       _event(other._event),
-      _inherit_kpi_downtime(other._inherit_kpi_downtime) {}
+      _dt_behaviour(other._dt_behaviour) {}
 
 /**
  *  Destructor.
@@ -83,7 +83,7 @@ ba& ba::operator=(ba const& other) {
     _warning_level = other._warning_level;
     _critical_level = other._critical_level;
     _event = other._event;
-    _inherit_kpi_downtime = other._inherit_kpi_downtime;
+    _dt_behaviour = other._dt_behaviour;
   }
   return (*this);
 }
@@ -102,7 +102,7 @@ bool ba::operator==(ba const& right) const {
           (_warning_level == right._warning_level) &&
           (_critical_level == right._critical_level) &&
           (_event == right._event) &&
-          (_inherit_kpi_downtime == right._inherit_kpi_downtime));
+          (_dt_behaviour == right._dt_behaviour));
 }
 
 /**
@@ -193,8 +193,8 @@ com::centreon::broker::bam::ba_event const& ba::get_opened_event() const {
  *
  *  @return  True if the BA should inherit the downtime of its kpis.
  */
-bool ba::get_inherit_kpi_downtime() const {
-  return (_inherit_kpi_downtime);
+ba::downtime_behaviour ba::get_downtime_behaviour() const {
+  return (_dt_behaviour);
 }
 
 /**
@@ -274,6 +274,6 @@ void ba::set_opened_event(bam::ba_event const& e) {
  *
  *  @param[in] value The value of the inherit kpi downtime flag.
  */
-void ba::set_inherit_kpi_downtime(bool value) {
-  _inherit_kpi_downtime = value;
+void ba::set_downtime_behaviour(ba::downtime_behaviour value) {
+  _dt_behaviour = value;
 }

--- a/bam/src/configuration/reader_v2.cc
+++ b/bam/src/configuration/reader_v2.cc
@@ -17,9 +17,11 @@
 */
 
 #include "com/centreon/broker/bam/configuration/reader_v2.hh"
+
 #include <cstring>
 #include <memory>
 #include <sstream>
+
 #include "com/centreon/broker/bam/configuration/reader_exception.hh"
 #include "com/centreon/broker/bam/configuration/state.hh"
 #include "com/centreon/broker/bam/dimension_ba_bv_relation_event.hh"
@@ -225,7 +227,8 @@ void reader_v2::_load(state::bas& bas, bam::ba_svc_mapping& mapping) {
                               res.value_as_u32(2)),  // State source.
                           res.value_as_f32(3),       // Warning level.
                           res.value_as_f32(4),       // Critical level.
-                          res.value_as_bool(8));     // Downtime inheritance.
+                          static_cast<configuration::ba::downtime_behaviour>(
+                              res.value_as_u32(8)));  // Downtime inheritance.
 
           // BA state.
           if (!res.value_is_null(5)) {

--- a/bam/test/ba/kpi_change_at_recompute.cc
+++ b/bam/test/ba/kpi_change_at_recompute.cc
@@ -26,6 +26,7 @@
 #include "com/centreon/broker/bam/kpi_service.hh"
 #include "com/centreon/broker/config/applier/init.hh"
 #include "com/centreon/broker/exceptions/msg.hh"
+#include "com/centreon/broker/neb/downtime.hh"
 #include "com/centreon/broker/neb/service_status.hh"
 
 using namespace com::centreon::broker;
@@ -429,6 +430,521 @@ TEST_F(BamBA, RatioPercent) {
 
     short val = results.top();
     ASSERT_EQ(test_ba->get_state_soft(), val);
+    ASSERT_EQ(test_ba->get_state_hard(), val);
+    results.pop();
+  }
+}
+
+TEST_F(BamBA, DtInheritAllCritical) {
+  std::shared_ptr<bam::ba> test_ba(new bam::ba);
+  test_ba->set_state_source(bam::configuration::ba::state_source_ratio_percent);
+  test_ba->set_level_critical(100);
+  test_ba->set_level_warning(75);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_inherit);
+
+  std::vector<std::shared_ptr<bam::kpi_service> > kpis;
+  std::stack<bool> results;
+
+  results.push(true);
+  results.push(false);
+  results.push(false);
+  results.push(false);
+
+  std::shared_ptr<bam::kpi_service> s1{new bam::kpi_service};
+  kpis.push_back(s1);
+  std::shared_ptr<bam::kpi_service> s2{new bam::kpi_service};
+  kpis.push_back(s2);
+  std::shared_ptr<bam::kpi_service> s3{new bam::kpi_service};
+  kpis.push_back(s3);
+  std::shared_ptr<bam::kpi_service> s4{new bam::kpi_service};
+  kpis.push_back(s4);
+
+  for (size_t i = 0; i < kpis.size(); i++) {
+    kpis[i]->set_host_id(i + 1);
+    kpis[i]->set_service_id(1);
+    kpis[i]->set_state_hard(bam::kpi_service::state::state_critical);
+    kpis[i]->set_state_soft(kpis[i]->get_state_hard());
+    test_ba->add_impact(kpis[i]);
+    kpis[i]->add_parent(test_ba);
+  }
+
+  // Change KPI state as much time as needed to trigger a
+  // recomputation. Note that the loop must terminate on a odd number
+  // for the test to be correct.
+  time_t now(time(nullptr));
+
+  std::shared_ptr<neb::service_status> ss(new neb::service_status);
+  std::shared_ptr<neb::downtime> dt(new neb::downtime);
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    ss->last_hard_state = 2;
+    kpis[j]->service_update(ss);
+
+    dt->host_id = ss->host_id;
+    dt->service_id = 1;
+    dt->was_started = true;
+    dt->actual_end_time = 0;
+    kpis[j]->service_update(dt);
+
+    short val = results.top();
+    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    results.pop();
+  }
+}
+
+TEST_F(BamBA, DtInheritOneOK) {
+  std::shared_ptr<bam::ba> test_ba(new bam::ba);
+  test_ba->set_state_source(bam::configuration::ba::state_source_ratio_percent);
+  test_ba->set_level_critical(100);
+  test_ba->set_level_warning(90);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_inherit);
+
+  std::vector<std::shared_ptr<bam::kpi_service> > kpis;
+  std::stack<bool> results;
+
+  results.push(false);
+  results.push(false);
+  results.push(false);
+  results.push(false);
+
+  std::shared_ptr<bam::kpi_service> s1{new bam::kpi_service};
+  kpis.push_back(s1);
+  std::shared_ptr<bam::kpi_service> s2{new bam::kpi_service};
+  kpis.push_back(s2);
+  std::shared_ptr<bam::kpi_service> s3{new bam::kpi_service};
+  kpis.push_back(s3);
+  std::shared_ptr<bam::kpi_service> s4{new bam::kpi_service};
+  kpis.push_back(s4);
+
+  for (size_t i = 0; i < kpis.size(); i++) {
+    kpis[i]->set_host_id(i + 1);
+    kpis[i]->set_service_id(1);
+    if (i == 0)
+      kpis[i]->set_state_hard(bam::kpi_service::state::state_ok);
+    else
+      kpis[i]->set_state_hard(bam::kpi_service::state::state_critical);
+    kpis[i]->set_state_soft(kpis[i]->get_state_hard());
+    test_ba->add_impact(kpis[i]);
+    kpis[i]->add_parent(test_ba);
+  }
+
+  // Change KPI state as much time as needed to trigger a
+  // recomputation. Note that the loop must terminate on a odd number
+  // for the test to be correct.
+  time_t now(time(nullptr));
+
+  std::shared_ptr<neb::service_status> ss(new neb::service_status);
+  std::shared_ptr<neb::downtime> dt(new neb::downtime);
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    if (j == 0)
+      ss->last_hard_state = 0;
+    else
+      ss->last_hard_state = 2;
+    kpis[j]->service_update(ss);
+
+    dt->host_id = ss->host_id;
+    dt->service_id = 1;
+    dt->was_started = true;
+    dt->actual_end_time = 0;
+    kpis[j]->service_update(dt);
+
+    short val = results.top();
+    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    results.pop();
+  }
+}
+
+
+TEST_F(BamBA, IgnoreDt) {
+  std::shared_ptr<bam::ba> test_ba(new bam::ba);
+  test_ba->set_state_source(bam::configuration::ba::state_source_ratio_percent);
+  test_ba->set_level_critical(100);
+  test_ba->set_level_warning(75);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_ignore);
+
+  std::vector<std::shared_ptr<bam::kpi_service> > kpis;
+  std::stack<bool> results;
+
+  results.push(false);
+  results.push(false);
+  results.push(false);
+  results.push(false);
+
+  std::shared_ptr<bam::kpi_service> s1{new bam::kpi_service};
+  kpis.push_back(s1);
+  std::shared_ptr<bam::kpi_service> s2{new bam::kpi_service};
+  kpis.push_back(s2);
+  std::shared_ptr<bam::kpi_service> s3{new bam::kpi_service};
+  kpis.push_back(s3);
+  std::shared_ptr<bam::kpi_service> s4{new bam::kpi_service};
+  kpis.push_back(s4);
+
+  for (size_t i = 0; i < kpis.size(); i++) {
+    kpis[i]->set_host_id(i + 1);
+    kpis[i]->set_service_id(1);
+    kpis[i]->set_state_hard(bam::kpi_service::state::state_critical);
+    kpis[i]->set_state_soft(kpis[i]->get_state_hard());
+    test_ba->add_impact(kpis[i]);
+    kpis[i]->add_parent(test_ba);
+  }
+
+  // Change KPI state as much time as needed to trigger a
+  // recomputation. Note that the loop must terminate on a odd number
+  // for the test to be correct.
+  time_t now(time(nullptr));
+
+  std::shared_ptr<neb::service_status> ss(new neb::service_status);
+  std::shared_ptr<neb::downtime> dt(new neb::downtime);
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    ss->last_hard_state = 2;
+    kpis[j]->service_update(ss);
+
+    dt->host_id = ss->host_id;
+    dt->service_id = 1;
+    dt->was_started = true;
+    dt->actual_end_time = 0;
+    kpis[j]->service_update(dt);
+
+    short val = results.top();
+    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    results.pop();
+  }
+}
+
+TEST_F(BamBA, DtIgnoreKpi) {
+  std::shared_ptr<bam::ba> test_ba(new bam::ba);
+  test_ba->set_state_source(bam::configuration::ba::state_source_ratio_percent);
+  test_ba->set_level_critical(100);
+  test_ba->set_level_warning(75);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_ignore_kpi);
+
+  std::vector<std::shared_ptr<bam::kpi_service> > kpis;
+  std::stack<bool> results;
+
+  results.push(false);
+  results.push(false);
+  results.push(false);
+  results.push(false);
+
+  std::shared_ptr<bam::kpi_service> s1{new bam::kpi_service};
+  kpis.push_back(s1);
+  std::shared_ptr<bam::kpi_service> s2{new bam::kpi_service};
+  kpis.push_back(s2);
+  std::shared_ptr<bam::kpi_service> s3{new bam::kpi_service};
+  kpis.push_back(s3);
+  std::shared_ptr<bam::kpi_service> s4{new bam::kpi_service};
+  kpis.push_back(s4);
+
+  for (size_t i = 0; i < kpis.size(); i++) {
+    kpis[i]->set_host_id(i + 1);
+    kpis[i]->set_service_id(1);
+    kpis[i]->set_state_hard(bam::kpi_service::state::state_critical);
+    kpis[i]->set_state_soft(kpis[i]->get_state_hard());
+    test_ba->add_impact(kpis[i]);
+    kpis[i]->add_parent(test_ba);
+  }
+
+  // Change KPI state as much time as needed to trigger a
+  // recomputation. Note that the loop must terminate on a odd number
+  // for the test to be correct.
+  time_t now(time(nullptr));
+
+  std::shared_ptr<neb::service_status> ss(new neb::service_status);
+  std::shared_ptr<neb::downtime> dt(new neb::downtime);
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    ss->last_hard_state = 2;
+    kpis[j]->service_update(ss);
+
+    dt->host_id = ss->host_id;
+    dt->service_id = 1;
+    dt->was_started = true;
+    dt->actual_end_time = 0;
+    kpis[j]->service_update(dt);
+
+    short val = results.top();
+    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    results.pop();
+  }
+}
+
+TEST_F(BamBA, DtIgnoreKpiImpact) {
+  std::shared_ptr<bam::ba> test_ba(new bam::ba);
+  test_ba->set_state_source(bam::configuration::ba::state_source_impact);
+  test_ba->set_level_critical(50);
+  test_ba->set_level_warning(75);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_ignore_kpi);
+
+  std::vector<std::shared_ptr<bam::kpi_service> > kpis;
+  std::stack<short> results;
+
+  results.push(0);
+  results.push(0);
+  results.push(1);
+  results.push(2);
+
+  std::shared_ptr<bam::kpi_service> s1{new bam::kpi_service};
+  kpis.push_back(s1);
+  std::shared_ptr<bam::kpi_service> s2{new bam::kpi_service};
+  kpis.push_back(s2);
+  std::shared_ptr<bam::kpi_service> s3{new bam::kpi_service};
+  kpis.push_back(s3);
+  std::shared_ptr<bam::kpi_service> s4{new bam::kpi_service};
+  kpis.push_back(s4);
+
+  for (size_t i = 0; i < kpis.size(); i++) {
+    kpis[i]->set_host_id(i + 1);
+    kpis[i]->set_service_id(1);
+    if (i == 3)
+      kpis[i]->set_state_hard(bam::kpi_service::state::state_ok);
+    else
+      kpis[i]->set_state_hard(bam::kpi_service::state::state_critical);
+    kpis[i]->set_state_soft(kpis[i]->get_state_hard());
+    kpis[i]->set_impact_critical(25);
+    test_ba->add_impact(kpis[i]);
+    kpis[i]->add_parent(test_ba);
+  }
+
+  // Change KPI state as much time as needed to trigger a
+  // recomputation. Note that the loop must terminate on a odd number
+  // for the test to be correct.
+  time_t now(time(nullptr));
+
+  std::shared_ptr<neb::service_status> ss(new neb::service_status);
+  std::shared_ptr<neb::downtime> dt(new neb::downtime);
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    if (j == 3)
+      ss->last_hard_state = 0;
+    else
+      ss->last_hard_state = 2;
+    kpis[j]->service_update(ss);
+
+    dt->host_id = ss->host_id;
+    dt->service_id = 1;
+    dt->was_started = true;
+    dt->actual_end_time = 0;
+    kpis[j]->service_update(dt);
+
+    short val = results.top();
+    ASSERT_EQ(test_ba->get_state_hard(), val);
+    results.pop();
+  }
+}
+
+TEST_F(BamBA, DtIgnoreKpiBest) {
+  std::shared_ptr<bam::ba> test_ba(new bam::ba);
+  test_ba->set_state_source(bam::configuration::ba::state_source_best);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_ignore_kpi);
+
+  std::vector<std::shared_ptr<bam::kpi_service> > kpis;
+  std::stack<short> results;
+
+  results.push(0);
+  results.push(2);
+  results.push(1);
+  results.push(0);
+
+  std::shared_ptr<bam::kpi_service> s1{new bam::kpi_service};
+  kpis.push_back(s1);
+  std::shared_ptr<bam::kpi_service> s2{new bam::kpi_service};
+  kpis.push_back(s2);
+  std::shared_ptr<bam::kpi_service> s3{new bam::kpi_service};
+  kpis.push_back(s3);
+  std::shared_ptr<bam::kpi_service> s4{new bam::kpi_service};
+  kpis.push_back(s4);
+
+  for (size_t i = 0; i < kpis.size(); i++) {
+    kpis[i]->set_host_id(i + 1);
+    kpis[i]->set_service_id(1);
+    switch (i) {
+      case 0:
+      case 1:
+        kpis[i]->set_state_hard(bam::kpi_service::state::state_ok);
+        break;
+      case 2:
+        kpis[i]->set_state_hard(bam::kpi_service::state::state_warning);
+        break;
+      case 3:
+        kpis[i]->set_state_hard(bam::kpi_service::state::state_critical);
+        break;
+    }
+
+    kpis[i]->set_state_soft(kpis[i]->get_state_hard());
+    test_ba->add_impact(kpis[i]);
+    kpis[i]->add_parent(test_ba);
+  }
+
+  // Change KPI state as much time as needed to trigger a
+  // recomputation. Note that the loop must terminate on a odd number
+  // for the test to be correct.
+  time_t now(time(nullptr));
+
+  std::shared_ptr<neb::service_status> ss(new neb::service_status);
+  std::shared_ptr<neb::downtime> dt(new neb::downtime);
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    ss->last_hard_state = kpis[j]->get_state_hard();
+    kpis[j]->service_update(ss);
+
+    dt->host_id = ss->host_id;
+    dt->service_id = 1;
+    dt->was_started = true;
+    dt->actual_end_time = 0;
+    kpis[j]->service_update(dt);
+
+    short val = results.top();
+    ASSERT_EQ(test_ba->get_state_hard(), val);
+    results.pop();
+  }
+}
+
+
+TEST_F(BamBA, DtIgnoreKpiWorst) {
+  std::shared_ptr<bam::ba> test_ba(new bam::ba);
+  test_ba->set_state_source(bam::configuration::ba::state_source_worst);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_ignore_kpi);
+
+  std::vector<std::shared_ptr<bam::kpi_service> > kpis;
+  std::stack<short> results;
+
+  results.push(0);
+  results.push(0);
+  results.push(1);
+  results.push(2);
+
+  std::shared_ptr<bam::kpi_service> s1{new bam::kpi_service};
+  kpis.push_back(s1);
+  std::shared_ptr<bam::kpi_service> s2{new bam::kpi_service};
+  kpis.push_back(s2);
+  std::shared_ptr<bam::kpi_service> s3{new bam::kpi_service};
+  kpis.push_back(s3);
+  std::shared_ptr<bam::kpi_service> s4{new bam::kpi_service};
+  kpis.push_back(s4);
+
+  for (size_t i = 0; i < kpis.size(); i++) {
+    kpis[i]->set_host_id(i + 1);
+    kpis[i]->set_service_id(1);
+    switch (i) {
+      case 0:
+      case 1:
+        kpis[i]->set_state_hard(bam::kpi_service::state::state_critical);
+        break;
+      case 2:
+        kpis[i]->set_state_hard(bam::kpi_service::state::state_warning);
+        break;
+      case 3:
+        kpis[i]->set_state_hard(bam::kpi_service::state::state_ok);
+        break;
+    }
+
+    kpis[i]->set_state_soft(kpis[i]->get_state_hard());
+    test_ba->add_impact(kpis[i]);
+    kpis[i]->add_parent(test_ba);
+  }
+
+  // Change KPI state as much time as needed to trigger a
+  // recomputation. Note that the loop must terminate on a odd number
+  // for the test to be correct.
+  time_t now(time(nullptr));
+
+  std::shared_ptr<neb::service_status> ss(new neb::service_status);
+  std::shared_ptr<neb::downtime> dt(new neb::downtime);
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    ss->last_hard_state = kpis[j]->get_state_hard();
+    kpis[j]->service_update(ss);
+
+    dt->host_id = ss->host_id;
+    dt->service_id = 1;
+    dt->was_started = true;
+    dt->actual_end_time = 0;
+    kpis[j]->service_update(dt);
+
+    short val = results.top();
+    ASSERT_EQ(test_ba->get_state_hard(), val);
+    results.pop();
+  }
+}
+
+TEST_F(BamBA, DtIgnoreKpiRatio) {
+  std::shared_ptr<bam::ba> test_ba(new bam::ba);
+  test_ba->set_state_source(bam::configuration::ba::state_source_ratio_number);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_ignore_kpi);
+  test_ba->set_level_warning(1);
+  test_ba->set_level_critical(2);
+
+  std::vector<std::shared_ptr<bam::kpi_service> > kpis;
+  std::stack<short> results;
+
+  results.push(0);
+  results.push(1);
+  results.push(2);
+  results.push(2);
+
+  std::shared_ptr<bam::kpi_service> s1{new bam::kpi_service};
+  kpis.push_back(s1);
+  std::shared_ptr<bam::kpi_service> s2{new bam::kpi_service};
+  kpis.push_back(s2);
+  std::shared_ptr<bam::kpi_service> s3{new bam::kpi_service};
+  kpis.push_back(s3);
+  std::shared_ptr<bam::kpi_service> s4{new bam::kpi_service};
+  kpis.push_back(s4);
+
+  for (size_t i = 0; i < kpis.size(); i++) {
+    kpis[i]->set_host_id(i + 1);
+    kpis[i]->set_service_id(1);
+    kpis[i]->set_state_hard(bam::kpi_service::state::state_critical);
+    kpis[i]->set_state_soft(kpis[i]->get_state_hard());
+    test_ba->add_impact(kpis[i]);
+    kpis[i]->add_parent(test_ba);
+  }
+
+  // Change KPI state as much time as needed to trigger a
+  // recomputation. Note that the loop must terminate on a odd number
+  // for the test to be correct.
+  time_t now(time(nullptr));
+
+  std::shared_ptr<neb::service_status> ss(new neb::service_status);
+  std::shared_ptr<neb::downtime> dt(new neb::downtime);
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    ss->last_hard_state = kpis[j]->get_state_hard();
+    kpis[j]->service_update(ss);
+
+    dt->host_id = ss->host_id;
+    dt->service_id = 1;
+    dt->was_started = true;
+    dt->actual_end_time = 0;
+    kpis[j]->service_update(dt);
+
+    short val = results.top();
     ASSERT_EQ(test_ba->get_state_hard(), val);
     results.pop();
   }


### PR DESCRIPTION
# Pull Request Template

## Description

Add support for the new BA Dowtime behaviour. Now a BA can 
- inherit the downtime
- ignore the downtime
- ignore a kpi that is in downtime.

* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** #BAM-834

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

You need to have the new calculation interface in bam and play with the ba downtime configuration

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [X] I have made sure that the **unit tests** related to the story are successful.
- [X] I have made sure that **unit tests cover 80%** of the code written for the story.
