### PR TITLE
enh(bam): fix some race in bam_reporting_relations_kpi_ba_events...(20.04)

### DIFF
--- a/bam/inc/com/centreon/broker/bam/kpi.hh
+++ b/bam/inc/com/centreon/broker/bam/kpi.hh
@@ -43,6 +43,7 @@ class impact_values;
 class kpi : public computable {
  protected:
   uint32_t _id;
+  uint32_t _ba_id;
   std::shared_ptr<kpi_event> _event;
   std::vector<std::shared_ptr<kpi_event> > _initial_events;
 
@@ -52,10 +53,12 @@ class kpi : public computable {
   kpi& operator=(kpi const& right) = delete;
   kpi(kpi const& right) = delete;
   uint32_t get_id() const;
+  uint32_t get_ba_id() const;
   timestamp get_last_state_change() const;
   virtual void impact_hard(impact_values& hard_impact) = 0;
   virtual void impact_soft(impact_values& soft_impact) = 0;
   void set_id(uint32_t id);
+  void set_ba_id(uint32_t id);
   virtual void set_initial_event(kpi_event const& e);
   virtual void visit(io::stream* visitor) = 0;
   virtual bool in_downtime() const;

--- a/bam/inc/com/centreon/broker/bam/kpi_event.hh
+++ b/bam/inc/com/centreon/broker/bam/kpi_event.hh
@@ -58,6 +58,7 @@ class kpi_event : public io::data {
   std::string perfdata;
   timestamp start_time;
   short status;
+  uint32_t ba_id;
 
   static mapping::entry const entries[];
   static io::event_info::event_operations const operations;

--- a/bam/inc/com/centreon/broker/bam/reporting_stream.hh
+++ b/bam/inc/com/centreon/broker/bam/reporting_stream.hh
@@ -22,7 +22,9 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <unordered_map>
 #include <vector>
+
 #include "com/centreon/broker/bam/availability_thread.hh"
 #include "com/centreon/broker/bam/ba_event.hh"
 #include "com/centreon/broker/bam/timeperiod_map.hh"
@@ -107,6 +109,7 @@ class reporting_stream : public io::stream {
   database::mysql_stmt _kpi_full_event_insert;
   database::mysql_stmt _kpi_event_update;
   database::mysql_stmt _kpi_event_link;
+  database::mysql_stmt _kpi_event_link_update;
   database::mysql_stmt _dimension_ba_insert;
   database::mysql_stmt _dimension_bv_insert;
   database::mysql_stmt _dimension_ba_bv_relation_insert;
@@ -121,7 +124,9 @@ class reporting_stream : public io::stream {
   // Timeperiods by BAs, with an option is default timeperiod.
   timeperiod_map _timeperiods;
 
-  std::vector<std::shared_ptr<io::data> > _dimension_data_cache;
+  std::vector<std::shared_ptr<io::data>> _dimension_data_cache;
+  std::unordered_map<uint32_t, std::map<std::time_t, uint64_t>>
+      _last_inserted_kpi;  // ba_id => <time, row>
 };
 }  // namespace bam
 

--- a/bam/src/configuration/applier/kpi.cc
+++ b/bam/src/configuration/applier/kpi.cc
@@ -324,6 +324,7 @@ std::shared_ptr<bam::kpi> applier::kpi::_new_kpi(
           << " nor a meta-service, nor a boolean expression");
 
   my_kpi->set_id(cfg.get_id());
+  my_kpi->set_ba_id(cfg.get_ba_id());
 
   return (my_kpi);
 }

--- a/bam/src/configuration/reader_v2.cc
+++ b/bam/src/configuration/reader_v2.cc
@@ -144,6 +144,7 @@ void reader_v2::_load(state::kpis& kpis) {
         if (!res.value_is_null(17)) {
           kpi_event e;
           e.kpi_id = kpi_id;
+          e.ba_id = res.value_as_u32(4);
           e.status = res.value_as_i32(8);
           e.start_time = res.value_as_u64(17);
           e.in_downtime = res.value_as_bool(18);

--- a/bam/src/kpi.cc
+++ b/bam/src/kpi.cc
@@ -43,6 +43,16 @@ uint32_t kpi::get_id() const {
 }
 
 /**
+ *  Get BA ID impacted by KPI.
+ *
+ *  @return BA ID.
+ */
+uint32_t kpi::get_ba_id() const {
+  return (_ba_id);
+}
+
+
+/**
  *  Get the last state change.
  *
  *  @return Last state change.
@@ -60,6 +70,17 @@ void kpi::set_id(uint32_t id) {
   _id = id;
   return;
 }
+
+/**
+ *  Set BA id impacted by KPI.
+ *
+ *  @param[in] id KPI ID.
+ */
+void kpi::set_ba_id(uint32_t id) {
+  _ba_id = id;
+  return ;
+}
+
 
 /**
  *  Set the initial event of the kpi.

--- a/bam/src/kpi_ba.cc
+++ b/bam/src/kpi_ba.cc
@@ -248,6 +248,7 @@ void kpi_ba::_open_new_event(io::stream* visitor,
                              timestamp event_start_time) {
   _event.reset(new kpi_event);
   _event->kpi_id = _id;
+  _event->ba_id = _ba_id;
   _event->impact_level = impact;
   _event->in_downtime = _ba->get_in_downtime();
   _event->output = _ba->get_output();

--- a/bam/src/kpi_boolexp.cc
+++ b/bam/src/kpi_boolexp.cc
@@ -206,6 +206,7 @@ void kpi_boolexp::_open_new_event(io::stream* visitor,
                                   kpi_boolexp::state state) {
   _event.reset(new kpi_event);
   _event->kpi_id = _id;
+  _event->ba_id = _ba_id;
   _event->impact_level = impact;
   _event->in_downtime = false;
   _event->output = "BAM boolean expression computed by Centreon Broker";

--- a/bam/src/kpi_event.cc
+++ b/bam/src/kpi_event.cc
@@ -30,7 +30,7 @@ kpi_event::kpi_event()
     : kpi_id(0),
       impact_level(0),
       in_downtime(false),
-      status(kpi_event::state::state_unknown) {}
+      status(kpi_event::state::state_unknown), ba_id(0) {}
 
 /**
  *  Copy constructor.
@@ -73,7 +73,7 @@ bool kpi_event::operator==(kpi_event const& other) const {
           (impact_level == other.impact_level) &&
           (in_downtime == other.in_downtime) && (output == other.output) &&
           (perfdata == other.perfdata) && (start_time == other.start_time) &&
-          (status == other.status));
+          (status == other.status) && (ba_id == other.ba_id));
 }
 
 /**
@@ -108,7 +108,7 @@ void kpi_event::_internal_copy(kpi_event const& other) {
   perfdata = other.perfdata;
   start_time = other.start_time;
   status = other.status;
-  return;
+  ba_id = other.ba_id;
 }
 
 /**************************************

--- a/bam/src/kpi_meta.cc
+++ b/bam/src/kpi_meta.cc
@@ -212,6 +212,7 @@ void kpi_meta::_fill_impact(impact_values& impact) {
 void kpi_meta::_open_new_event(io::stream* visitor, int impact, short state) {
   _event.reset(new kpi_event);
   _event->kpi_id = _id;
+  _event->ba_id = _ba_id;
   _event->impact_level = impact;
   _event->in_downtime = false;
   _event->output = _meta->get_output();

--- a/bam/src/kpi_service.cc
+++ b/bam/src/kpi_service.cc
@@ -435,6 +435,7 @@ void kpi_service::_open_new_event(io::stream* visitor,
                                   impact_values const& impacts) {
   _event.reset(new kpi_event);
   _event->kpi_id = _id;
+  _event->ba_id = _ba_id;
   _event->impact_level =
       _event->in_downtime ? impacts.get_downtime() : impacts.get_nominal();
   _event->in_downtime = _downtimed;

--- a/core/inc/com/centreon/broker/mysql.hh
+++ b/core/inc/com/centreon/broker/mysql.hh
@@ -61,10 +61,19 @@ class mysql {
       std::promise<database::mysql_result>* promise,
       int thread_id = -1);
 
+  template <typename T>
   int run_statement_and_get_int(database::mysql_stmt& stmt,
-                                std::promise<int>* promise,
+                                std::promise<T>* promise,
                                 database::mysql_task::int_type type,
-                                int thread_id = -1);
+                                int thread_id = -1) {
+    _check_errors();
+    if (thread_id < 0)
+      // Here, we use _current_thread
+      thread_id = choose_best_connection();
+
+    _connection[thread_id]->run_statement_and_get_int<T>(stmt, promise, type);
+    return thread_id;
+  }
 
   bool fetch_row(database::mysql_result& res);
   int get_last_insert_id(int thread_id);

--- a/core/inc/com/centreon/broker/mysql_connection.hh
+++ b/core/inc/com/centreon/broker/mysql_connection.hh
@@ -64,9 +64,13 @@ class mysql_connection {
   void run_statement_and_get_result(
       database::mysql_stmt& stmt,
       std::promise<database::mysql_result>* promise);
+
+  template <typename T>
   void run_statement_and_get_int(database::mysql_stmt& stmt,
-                                 std::promise<int>* promise,
-                                 database::mysql_task::int_type type);
+                                 std::promise<T>* promise,
+                                 database::mysql_task::int_type type) {
+    _push(std::make_shared<database::mysql_task_statement_int<T>>(stmt, promise, type));
+  }
 
   void finish();
   bool fetch_row(database::mysql_result& result);
@@ -90,6 +94,7 @@ class mysql_connection {
   void _prepare(database::mysql_task* t);
   void _statement(database::mysql_task* t);
   void _statement_res(database::mysql_task* t);
+  template <typename T>
   void _statement_int(database::mysql_task* t);
   void _get_result_sync(database::mysql_task* task);
   void _fetch_row_sync(database::mysql_task* task);

--- a/core/src/mysql.cc
+++ b/core/src/mysql.cc
@@ -264,35 +264,6 @@ int mysql::run_statement_and_get_result(database::mysql_stmt& stmt,
 }
 
 /**
- * This method looks like run_query_and_get_int but it is used to execute a
- * prepared statement.
- *
- * @param stmt The statement to execute.
- * @param promise A promise that will contain the result when it will be
- *                available.
- * @param error_msg An error message to complete the error message returned
- *                  by the mysql connector.
- * @param thread_id A thread id or 0 to keep the library choosing which one.
- *
- * With this function, the query is done. The promise will provide the result
- * if available and it will contain an exception if the query failed.
- *
- * @return The thread id that executed the query.
- */
-int mysql::run_statement_and_get_int(database::mysql_stmt& stmt,
-                                     std::promise<int>* promise,
-                                     mysql_task::int_type type,
-                                     int thread_id) {
-  _check_errors();
-  if (thread_id < 0)
-    // Here, we use _current_thread
-    thread_id = choose_best_connection();
-
-  _connection[thread_id]->run_statement_and_get_int(stmt, promise, type);
-  return thread_id;
-}
-
-/**
  *  This method prepares a statement.
  *
  * @param stmt The statement to prepare.

--- a/storage/src/conflict_manager_storage.cc
+++ b/storage/src/conflict_manager_storage.cc
@@ -134,7 +134,7 @@ int32_t conflict_manager::_storage_process_service_status() {
     _index_data_insert.bind_value_as_str(4, "0");
     _index_data_insert.bind_value_as_str(5, special ? "1" : "0");
     std::promise<int> promise;
-    _mysql.run_statement_and_get_int(_index_data_insert,
+    _mysql.run_statement_and_get_int<int>(_index_data_insert,
                                      &promise,
                                      database::mysql_task::LAST_INSERT_ID,
                                      conn);
@@ -280,7 +280,7 @@ int32_t conflict_manager::_storage_process_service_status() {
 
             // Execute query.
             std::promise<int> promise;
-            _mysql.run_statement_and_get_int(
+            _mysql.run_statement_and_get_int<int>(
               _metrics_insert,
               &promise,
               database::mysql_task::LAST_INSERT_ID,


### PR DESCRIPTION
# Pull Request Template

## Description

Steps to reproduce the issue:

Create a BA and check "Automatically inherit KPI downtimes ?"
Set a Downtime on a KPI
Simulate a critical on this KPI (So my BA is in downtime)
Remove the downtime on my KPI (So my BA is not anymore in downtime)
Describe the results you received:
I have no kpi_event_id list for my ba_event_id when my the downtime is removed :
SELECT ba_event_id, ba_id, FROM_UNIXTIME(start_time) as start_time, first_level, FROM_UNIXTIME(end_time) as end_time, status, in_downtime FROM mod_bam_reporting_ba_events;
+-------------+-------+---------------------+-------------+---------------------+--------+-------------+
| ba_event_id | ba_id | start_time | first_level | end_time | status | in_downtime |
+-------------+-------+---------------------+-------------+---------------------+--------+-------------+
| 1 | 1 | 2019-08-02 16:12:33 | 100 | 2019-08-02 16:19:26 | 0 | 0 |
| 2 | 1 | 2019-08-02 16:19:26 | 50 | 2019-08-02 16:24:26 | 2 | 1 |
| 3 | 1 | 2019-08-02 16:24:26 | 50 | 2019-08-02 16:34:26 | 2 | 0 |
| 4 | 1 | 2019-08-02 16:34:26 | 100 | NULL | 0 | 0 |
+-------------+-------+---------------------+-------------+---------------------+--------+-------------+

SELECT kpi.kpi_event_id, kpi_id, FROM_UNIXTIME(start_time) as start_time, FROM_UNIXTIME(end_time) as end_time, status, in_downtime, impact_level, first_output, first_perfdata FROM mod_bam_reporting_kpi_events kpi, mod_bam_reporting_relations_ba_kpi_events r WHERE kpi.kpi_event_id=r.kpi_event_id AND r.ba_event_id=3;
Empty set (0.00 sec)

Describe the results you expected:

SELECT kpi.kpi_event_id, kpi_id, FROM_UNIXTIME(start_time) as start_time, FROM_UNIXTIME(end_time) as end_time, status, in_downtime, impact_level, first_output, first_perfdata FROM mod_bam_reporting_kpi_events kpi, mod_bam_reporting_relations_ba_kpi_events r WHERE kpi.kpi_event_id=r.kpi_event_id AND r.ba_event_id=2 and status != 0;
+--------------+--------+---------------------+---------------------+--------+-------------+--------------+---------------------------------------------------+-------------------+
| kpi_event_id | kpi_id | start_time | end_time | status | in_downtime | impact_level | first_output | first_perfdata |
+--------------+--------+---------------------+---------------------+--------+-------------+--------------+---------------------------------------------------+-------------------+
| 2 | 2 | 2019-08-02 16:19:26 | 2019-08-02 16:24:26 | 2 | 1 | 50 | CRITICAL: Number of current processes running: 0
| 'nbproc'=0;;1:;0; |
| 5 | 2 | 2019-08-02 16:24:26 | 2019-08-02 16:34:26 | 2 | 0 | 50 | CRITICAL: Number of current processes running: 0
| 'nbproc'=0;;1:;0; |
+--------------+--------+---------------------+---------------------+--------+-------------+--------------+---------------------------------------------------+-------------------+
2 rows in set (0.00 sec)

The kpi_event_id = 5 normally must be linked to the ba_event_id 3

And so If I generate a report, I will have a exception with no linked KPI under it.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

see upper

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [X] I have made sure that the **unit tests** related to the story are successful.

