### PR TITLE
fix(tests): Here is a hack because we cannot use cmake3 for now

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set_directory_properties(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/3rdparty)
 set(GOOGLE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 ExternalProject_Add( googletest
                      GIT_REPOSITORY https://github.com/google/googletest/
+                     GIT_TAG release-1.10.0
                      TIMEOUT 10
                      INSTALL_COMMAND ""
                      LOG_DOWNLOAD ON


### PR DESCRIPTION
# Pull Request Template

## Description

We cannot at the moment change our cmake version to cmake3. So we force the release version of google-test to an older one.

No impact in production.