### PR TITLE
fix(failover): try to not wait too long when we shutdown the failover

### DIFF
--- a/core/src/processing/failover.cc
+++ b/core/src/processing/failover.cc
@@ -153,8 +153,10 @@ void failover::run() {
 
         // Wait loop.
         // FIXME DBR: attempt to replace the Qt code below.
-        if (!should_exit())
-          std::this_thread::sleep_for(std::chrono::seconds(_buffering_timeout));
+        // FIXME SGA: condvar should be more elegant...
+        for (size_t i = 0; !should_exit() && i < (_buffering_timeout * 10); i++) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
 
         _update_status("");
       }
@@ -355,8 +357,9 @@ void failover::run() {
     // Sleep a while before attempting a reconnection.
     _update_status("sleeping before reconnection");
 
-    if (!should_exit())
-      std::this_thread::sleep_for(std::chrono::seconds(_retry_interval));
+    for (size_t i = 0; !should_exit() && i < (_retry_interval * 10); i++) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
 
     _update_status("");
 


### PR DESCRIPTION
# Pull Request Template

## Description

remove some too big waits

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

stop centengine and cbd
restart centengine using: 

systemctl start centengine

look how long it take too stop it again : 

time systemctl stop centengine

It should take less than 2 seconds...

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

