### PR TITLE
fix(tcp): do not do async things on write errors...

### DIFF
--- a/tcp/inc/com/centreon/broker/tcp/stream.hh
+++ b/tcp/inc/com/centreon/broker/tcp/stream.hh
@@ -46,6 +46,7 @@ class acceptor;
 class stream : public io::stream {
  public:
   stream& operator=(stream const& other) = delete;
+  stream(stream const& other) = delete;
   stream(std::shared_ptr<asio::ip::tcp::socket> sock, std::string const& name);
   ~stream();
   std::string peer() const;
@@ -56,7 +57,6 @@ class stream : public io::stream {
   int write(std::shared_ptr<io::data> const& d);
 
  private:
-  stream(stream const& other);
   void _set_socket_options();
 
   std::string _name;
@@ -64,6 +64,7 @@ class stream : public io::stream {
   std::shared_ptr<asio::ip::tcp::socket> _socket;
   int _read_timeout;
   int _write_timeout;
+  bool _socket_gone;
 };
 }  // namespace tcp
 

--- a/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
+++ b/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
@@ -81,7 +81,7 @@ class tcp_async {
 
  public:
   void register_socket(asio::ip::tcp::socket& socket);
-  void unregister_socket(asio::ip::tcp::socket& socket);
+  void unregister_socket(asio::ip::tcp::socket& socket, bool sync);
 
   async_buf wait_for_packet(asio::ip::tcp::socket& socket,
                             time_t deadline,


### PR DESCRIPTION
fix(tcp): delete async only socket that are still in use...
fix some possible deadlock in socket_unregister.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [X] I have made sure that the **unit tests** related to the story are successful.
- [X] I have made sure that **unit tests cover 80%** of the code written for the story.
- [X] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
