### PR TITLE
fix(misc): xfs readdir does not fill d_type for DT_REG.

### DIFF
--- a/core/src/misc/filesystem.cc
+++ b/core/src/misc/filesystem.cc
@@ -54,10 +54,12 @@ std::list<std::string> filesystem::dir_content(std::string const& path,
       if (add_slash)
         fullname.append("/");
       fullname.append(ent->d_name);
-      if (recursive && ent->d_type == DT_DIR) {
+      struct stat st;
+      stat(fullname.c_str(), &st);
+      if (recursive && S_ISDIR(st.st_mode)) {
         std::list<std::string> res{filesystem::dir_content(fullname, true)};
         retval.splice(retval.end(), res);
-      } else if (ent->d_type == DT_REG)
+      } else if (S_ISREG(st.st_mode))
         retval.push_back(std::move(fullname));
     }
     closedir(dir);

--- a/core/src/misc/filesystem.cc
+++ b/core/src/misc/filesystem.cc
@@ -57,9 +57,9 @@ std::list<std::string> filesystem::dir_content(std::string const& path,
       if (recursive && ent->d_type & DT_DIR) {
         std::list<std::string> res{filesystem::dir_content(fullname, true)};
         retval.splice(retval.end(), res);
-      } else if (ent->d_type & DT_REG) {
+      } else if (ent->d_type == DT_REG) {
         retval.push_back(std::move(fullname));
-      } else if (ent->d_type & DT_UNKNOWN) {
+      } else if (ent->d_type == DT_UNKNOWN) {
         struct stat st;
         stat(fullname.c_str(), &st);
 

--- a/core/src/misc/filesystem.cc
+++ b/core/src/misc/filesystem.cc
@@ -54,7 +54,7 @@ std::list<std::string> filesystem::dir_content(std::string const& path,
       if (add_slash)
         fullname.append("/");
       fullname.append(ent->d_name);
-      if (recursive && ent->d_type & DT_DIR) {
+      if (recursive && ent->d_type == DT_DIR) {
         std::list<std::string> res{filesystem::dir_content(fullname, true)};
         retval.splice(retval.end(), res);
       } else if (ent->d_type == DT_REG) {


### PR DESCRIPTION
fix(misc): xfs readdir does not fill d_type for DT_REG.
This fix a broker loading issue on xfs filesystem.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Run broker on xfs, if it works, all works

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [X] I have made sure that the **unit tests** related to the story are successful.
- [X] I have made sure that **unit tests cover 80%** of the code written for the story.
- [X] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
