### PR TITLE
fix(rrd): rebuild when type is not GAUGE is fixed

### DIFF
--- a/storage/src/conflict_manager.cc
+++ b/storage/src/conflict_manager.cc
@@ -304,9 +304,9 @@ void conflict_manager::_load_caches() {
     std::promise<mysql_result> promise;
     _mysql.run_query_and_get_result(
         "SELECT "
-        "metric_id,index_id,metric_name,unit_name,warn,warn_low,warn_threshold_"
-        "mode,crit,crit_low,crit_threshold_mode,min,max,current_value,data_"
-        "source_type FROM metrics",
+        "metric_id,index_id,metric_name,unit_name,warn,warn_low,"
+        "warn_threshold_mode,crit,crit_low,crit_threshold_mode,min,max,"
+        "current_value,data_source_type FROM metrics",
         &promise);
 
     try {

--- a/storage/src/conflict_manager_storage.cc
+++ b/storage/src/conflict_manager_storage.cc
@@ -276,8 +276,7 @@ int32_t conflict_manager::_storage_process_service_status() {
             _metrics_insert.bind_value_as_f32(10, pd.max());
             _metrics_insert.bind_value_as_f32(11, pd.value());
 
-            uint32_t type = 0;  // FIXME DBR: can be one of the data_type
-            // proposed in perfdata.hh
+            uint32_t type = pd.value_type();
             char t[2];
             t[0] = '1' + type;
             t[1] = 0;
@@ -326,6 +325,8 @@ int32_t conflict_manager::_storage_process_service_status() {
           } else {
             /* We have the metric in the cache */
             metric_id = it_index_cache->second.metric_id;
+            pd.value_type(
+                static_cast<perfdata::data_type>(it_index_cache->second.type));
 
             log_v2::perfdata()->debug(
                 "conflict_manager: metric {} concerning index {}, perfdata "
@@ -394,8 +395,13 @@ int32_t conflict_manager::_storage_process_service_status() {
                     false, metric_id, rrd_len, pd.value(), pd.value_type())};
             log_v2::perfdata()->debug(
                 "conflict_manager: generating perfdata event for metric {} "
-                "(name '{}', ctime {}, value {}, rrd_len {})",
-                perf->metric_id, perf->name, perf->ctime, perf->value, rrd_len);
+                "(name '{}', ctime {}, value {}, rrd_len {}, data_type {})",
+                perf->metric_id,
+                perf->name,
+                perf->ctime,
+                perf->value,
+                rrd_len,
+                perf->value_type);
             multiplexing::publisher().write(perf);
           }
         }


### PR DESCRIPTION
# Pull Request Template

## Description

If you rebuild a metric it may not be rebuilt in the following cases:
* the metric is not of type GAUGE
* the metric changed of type just before the rebuild.

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)
