### PR TITLE
fix(storage): Regression in the perfdata parsing.

### DIFF
--- a/doc/release_notes/broker20.04.rst
+++ b/doc/release_notes/broker20.04.rst
@@ -11,6 +11,14 @@ New Lua function in the streamconnector
 There is a new function broker.stat(filename) to get informations about the
 filename.
 
+*********
+Bug fixes
+*********
+
+Perfdata parsing
+================
+Special characters like '\\r' were not parsed correctly.
+
 =======================
 Centreon Broker 20.04.0
 =======================

--- a/storage/src/parser.cc
+++ b/storage/src/parser.cc
@@ -268,7 +268,7 @@ void parser::parse_perfdata(const char* str, std::list<perfdata>& pd) {
     pd.emplace_back(std::move(p));
 
     // Skip whitespaces.
-    while (isblank(*tmp))
+    while (isspace(*tmp))
       ++tmp;
   }
 }

--- a/storage/test/perfdata.cc
+++ b/storage/test/perfdata.cc
@@ -554,3 +554,30 @@ TEST_F(StorageParserParsePerfdata, Complex2) {
   ASSERT_FALSE(expected != *it);
   ++it;
 }
+
+// Given a storage::parser object
+// When parse_perfdata() is called with a valid perfdata string
+// Then perfdata are returned in a list
+TEST_F(StorageParserParsePerfdata, SimpleWithR) {
+  // Parse perfdata.
+  std::list<storage::perfdata> lst;
+  storage::parser p;
+  //ASSERT_NO_THROW(p.parse_perfdata("'total'=5;;;0;\r", lst));
+  ASSERT_NO_THROW(p.parse_perfdata("'total'=5;;;0;\r", lst));
+
+  // Assertions.
+  ASSERT_EQ(lst.size(), 1u);
+  std::list<storage::perfdata>::const_iterator it(lst.begin());
+  storage::perfdata expected;
+  expected.name("total");
+  expected.value_type(storage::perfdata::gauge);
+  expected.value(5);
+  expected.unit("");
+  expected.warning(NAN);
+  expected.warning_low(0.0);
+  expected.critical(NAN);
+  expected.critical_low(0.0);
+  expected.min(0.0);
+  expected.max(NAN);
+  ASSERT_TRUE(expected == *it);
+}


### PR DESCRIPTION
# Pull Request Template

## Description

Parsing a perfdata with '\r' crashed.
It is fixed.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)
