### PR TITLE
fix(core): segfault fixed when mariadb is interrupted

### DIFF
--- a/core/src/mysql.cc
+++ b/core/src/mysql.cc
@@ -44,7 +44,12 @@ mysql::mysql(database_config const& db_cfg)
  */
 mysql::~mysql() {
   log_v2::sql()->debug("mysql: destruction");
-  commit();
+  try {
+    commit();
+  }
+  catch (const std::exception& e) {
+    log_v2::sql()->warn("Unable to commit on the database server. Probably not connected: {}", e.what());
+  }
   _connection.clear();
   mysql_manager::instance().update_connections();
   logging::info(logging::low) << "mysql: mysql library closed.";


### PR DESCRIPTION
# Pull Request Template

## Description

When connection to database is lost, connections to it should not commit any result, this cannot be done!

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)
