### PR TITLE
fix(bam): should not give a connection with error to a mysql object

### DIFF
--- a/core/src/mysql_manager.cc
+++ b/core/src/mysql_manager.cc
@@ -76,7 +76,7 @@ std::vector<std::shared_ptr<mysql_connection>> mysql_manager::get_connections(
     std::lock_guard<std::mutex> lock(_cfg_mutex);
     for (std::shared_ptr<mysql_connection>& c : _connection) {
       // Is this thread matching what the configuration needs?
-      if (c->match_config(db_cfg) && !c->is_finished()) {
+      if (c->match_config(db_cfg) && !c->is_finished() && !c->is_in_error()) {
         // Yes
         retval.push_back(c);
         ++current_connection;
@@ -124,7 +124,7 @@ void mysql_manager::update_connections() {
     } else
       ++it;
   }
-  log_v2::sql()->info("mysql_manager: still {} active connection{}",
+  log_v2::sql()->info("mysql_manager: currently {} active connection{}",
                       _connection.size(), _connection.size() > 1 ? "s" : "");
 
   if (_connection.size() == 0)

--- a/doc/en/release_notes/broker20.04.rst
+++ b/doc/en/release_notes/broker20.04.rst
@@ -11,6 +11,10 @@ Segfault possible during a Mariadb server restart
 Centreon broker could crash when the database server was restarted. This version
 fixes this bug.
 
+BAM module could never recovery after a Mariadb server restart
+==============================================================
+BAM module is better managed on database server reload/restart.
+
 =======================
 Centreon Broker 20.04.5
 =======================


### PR DESCRIPTION
If a connection is in error, it must be thrown away once all the mysql objects
have been restored. So the manager don't have to give it to a new mysql object.

This patch contains also a fix in mysql_connection concerning server errors in
case of queries returning a value.

And a little improvement in reader_v2, that does not use any more stringstream,
replaced by fmt::format.
