### PR TITLE
fix(storage): dead lock on host downtime insertion fixed

### DIFF
--- a/storage/src/conflict_manager_sql.cc
+++ b/storage/src/conflict_manager_sql.cc
@@ -544,7 +544,7 @@ void conflict_manager::_process_custom_variable_status(
  */
 void conflict_manager::_process_downtime(std::shared_ptr<io::data> d) {
   int conn = _mysql.choose_best_connection(neb::downtime::static_type());
-  _finish_action(-1, actions::hosts | actions::instances |
+  _finish_action(-1, actions::hosts | actions::instances | actions::downtimes |
                          actions::host_parents | actions::host_dependencies |
                          actions::service_dependencies);
 


### PR DESCRIPTION
# Pull Request Template

## Description

On host downtime insertion, we can have dead locks in the database.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

