### PR TITLE
Mon 6185 map duplicated connections

### DIFF
--- a/core/inc/com/centreon/broker/processing/feeder.hh
+++ b/core/inc/com/centreon/broker/processing/feeder.hh
@@ -20,11 +20,12 @@
 #define CCB_PROCESSING_FEEDER_HH
 
 #include <atomic>
-#include <condition_variable>
-#include <thread>
 #include <climits>
+#include <condition_variable>
 #include <memory>
 #include <string>
+#include <thread>
+
 #include "com/centreon/broker/misc/shared_mutex.hh"
 #include "com/centreon/broker/multiplexing/subscriber.hh"
 #include "com/centreon/broker/namespace.hh"
@@ -45,11 +46,7 @@ namespace processing {
  *  Take events from a source and send them to a destination.
  */
 class feeder : public stat_visitable {
-  enum state {
-    stopped,
-    running,
-    finished
-  };
+  enum state { stopped, running, finished };
   // Condition variable used when waiting for the thread to finish
   std::thread _thread;
   state _state;
@@ -80,7 +77,8 @@ class feeder : public stat_visitable {
   feeder(feeder const&) = delete;
   feeder& operator=(feeder const&) = delete;
   bool is_finished() const noexcept;
-  const std::string get_state() const;
+  const char* get_state() const;
+
  protected:
   uint32_t _get_queued_events() const override;
 };

--- a/core/inc/com/centreon/broker/processing/feeder.hh
+++ b/core/inc/com/centreon/broker/processing/feeder.hh
@@ -80,6 +80,7 @@ class feeder : public stat_visitable {
   feeder(feeder const&) = delete;
   feeder& operator=(feeder const&) = delete;
   bool is_finished() const noexcept;
+  const std::string get_state() const;
  protected:
   uint32_t _get_queued_events() const override;
 };

--- a/core/inc/com/centreon/broker/processing/stat_visitable.hh
+++ b/core/inc/com/centreon/broker/processing/stat_visitable.hh
@@ -44,7 +44,7 @@ class stat_visitable {
   std::atomic<uint32_t> _queued_events;
 
  protected:
-  std::string _name;
+  const std::string _name;
   mutable std::mutex _stat_mutex;
 
   virtual uint32_t _get_queued_events() const = 0;

--- a/core/inc/com/centreon/broker/processing/stat_visitable.hh
+++ b/core/inc/com/centreon/broker/processing/stat_visitable.hh
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_set>
+
 #include "com/centreon/broker/misc/processing_speed_computer.hh"
 #include "com/centreon/broker/timestamp.hh"
 

--- a/core/src/processing/acceptor.cc
+++ b/core/src/processing/acceptor.cc
@@ -16,13 +16,14 @@
 ** For more information : contact@centreon.com
 */
 
-#include <cassert>
 #include "com/centreon/broker/processing/acceptor.hh"
+
 #include <unistd.h>
-#include "com/centreon/broker/misc/misc.hh"
+
 #include "com/centreon/broker/io/endpoint.hh"
-#include "com/centreon/broker/logging/logging.hh"
 #include "com/centreon/broker/log_v2.hh"
+#include "com/centreon/broker/logging/logging.hh"
+#include "com/centreon/broker/misc/misc.hh"
 #include "com/centreon/broker/multiplexing/muxer.hh"
 #include "com/centreon/broker/processing/feeder.hh"
 
@@ -66,7 +67,8 @@ void acceptor::accept() {
 
     std::lock_guard<std::mutex> lock(_stat_mutex);
     _feeders.push_back(f);
-    log_v2::core()->trace("Currently {} connections to acceptor '{}'", _feeders.size(), _name);
+    log_v2::core()->trace("Currently {} connections to acceptor '{}'",
+                          _feeders.size(), _name);
   }
 }
 
@@ -81,8 +83,7 @@ void acceptor::exit() {
       break;
     case running:
       _should_exit = true;
-      _state_cv.wait(lck,
-                     [this] { return _state == acceptor::finished; });
+      _state_cv.wait(lck, [this] { return _state == acceptor::finished; });
       _thread.join();
       break;
     case finished:
@@ -183,8 +184,7 @@ void acceptor::start() {
   if (_state == stopped) {
     _should_exit = false;
     _thread = std::thread(&acceptor::_callback, this);
-    _state_cv.wait(lock,
-                   [this] { return _state == acceptor::running; });
+    _state_cv.wait(lock, [this] { return _state == acceptor::running; });
   }
 }
 
@@ -221,14 +221,13 @@ void acceptor::_callback() noexcept {
     {
       std::lock_guard<std::mutex> lock(_stat_mutex);
       for (auto it = _feeders.begin(), end = _feeders.end(); it != end;) {
-	log_v2::core()->trace("acceptor '{}' feeder '{}' state {}", _name, (*it)->get_name(), (*it)->get_state());
-        if (!(*it)->is_finished() && (*it)->get_state() == "finished")
-          assert(1==0);
+        log_v2::core()->trace("acceptor '{}' feeder '{}' state {}", _name,
+                              (*it)->get_name(), (*it)->get_state());
         if ((*it)->is_finished()) {
-          log_v2::core()->info("removing '{}' from acceptor '{}'", (*it)->get_name(), _name);
+          log_v2::core()->info("removing '{}' from acceptor '{}'",
+                               (*it)->get_name(), _name);
           it = _feeders.erase(it);
-        }
-        else
+        } else
           ++it;
       }
     }

--- a/core/src/processing/feeder.cc
+++ b/core/src/processing/feeder.cc
@@ -17,15 +17,16 @@
 */
 
 #include "com/centreon/broker/processing/feeder.hh"
+
 #include <unistd.h>
-#include <cassert>
+
 #include "com/centreon/broker/exceptions/msg.hh"
 #include "com/centreon/broker/exceptions/shutdown.hh"
 #include "com/centreon/broker/io/raw.hh"
 #include "com/centreon/broker/io/stream.hh"
+#include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/logging/logging.hh"
 #include "com/centreon/broker/multiplexing/muxer.hh"
-#include "com/centreon/broker/log_v2.hh"
 
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::processing;
@@ -65,7 +66,8 @@ feeder::feeder(std::string const& name,
   set_state("connecting");
   std::unique_lock<std::mutex> lck(_state_m);
   _thread = std::thread(&feeder::_callback, this);
-  _state_cv.wait(lck, [&state = this->_state] { return state != feeder::stopped; });
+  _state_cv.wait(lck,
+                 [& state = this->_state] { return state != feeder::stopped; });
 }
 
 /**
@@ -204,8 +206,8 @@ void feeder::_callback() noexcept {
         << "'";
   }
 
-  /* If we are here, that is because the loop is finished, and if we want is_finished()
-   * to return true, we have to set _should_exit to true. */
+  /* If we are here, that is because the loop is finished, and if we want
+   * is_finished() to return true, we have to set _should_exit to true. */
   _should_exit = true;
   std::unique_lock<std::mutex> lock_stop(_state_m);
   _state = feeder::finished;
@@ -226,7 +228,7 @@ uint32_t feeder::_get_queued_events() const {
   return _subscriber.get_muxer().get_event_queue_size();
 }
 
-const std::string feeder::get_state() const {
+const char* feeder::get_state() const {
   switch (_state) {
     case stopped:
       return "stopped";


### PR DESCRIPTION
# Pull Request Template

## Description

If you restart the Map Server, it is connected to centreon-broker, but the fixed bug here is that broker kept the previous connection to the map server. And that each time, the server was restarted...

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x
- [X] 20.10.x (master)
