### PR TITLE
fix(log_v2): when log_v2 is enabled, core is at info level by default

### DIFF
--- a/core/src/log_v2.cc
+++ b/core/src/log_v2.cc
@@ -109,9 +109,16 @@ bool log_v2::load(std::string const& file,
         }
       }
 
+      _core_log = std::make_shared<logger>("core", sinks.begin(), sinks.end());
+      _core_log->set_level(level::info);
+      _core_log->flush_on(level::info);
+      _core_log->info("{} : log started", broker_name);
+
       for (auto& entry : js["loggers"].array_items()) {
         std::shared_ptr<logger>* l;
-        if (entry["name"].string_value() == "tls")
+        if (entry["name"].string_value() == "core")
+          l = &_core_log;
+        else if (entry["name"].string_value() == "tls")
           l = &_tls_log;
         else if (entry["name"].string_value() == "tcp")
           l = &_tcp_log;
@@ -133,11 +140,6 @@ bool log_v2::load(std::string const& file,
         (*l)->set_level(dbg_lvls[entry["level"].string_value()]);
         (*l)->flush_on(dbg_lvls[entry["level"].string_value()]);
       }
-
-      _core_log = std::make_shared<logger>("core", sinks.begin(), sinks.end());
-      _core_log->set_level(level::trace);
-      _core_log->flush_on(level::trace);
-      _core_log->info("{} : log started", broker_name);
 
       return true;
     }


### PR DESCRIPTION
# Pull Request Template

## Description

With log_v2, core ways always at level "trace". Now, by default it is at level "info" and can be changed as the others.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
