### PR TITLE
Mon 6243 pool latency

### DIFF
--- a/core/inc/com/centreon/broker/pool.hh
+++ b/core/inc/com/centreon/broker/pool.hh
@@ -43,11 +43,12 @@ class pool {
   mutable std::mutex _closed_m;
   /* Latency in milliseconds between the call of check_latency and its real
    * execution. */
-  std::atomic<uint32_t> _latency;
+  std::atomic<double> _latency;
 
   pool();
   void _start();
   void _stop();
+  void _check_latency();
 
  public:
   ~pool() noexcept;
@@ -58,7 +59,7 @@ class pool {
   static pool& instance();
   static asio::io_context& io_context();
   size_t get_current_size() const;
-  void check_latency();
+  double get_latency() const;
 };
 
 CCB_END()

--- a/core/inc/com/centreon/broker/pool.hh
+++ b/core/inc/com/centreon/broker/pool.hh
@@ -31,6 +31,35 @@ CCB_BEGIN()
  * At the origin, this thread pool is configured to be used by ASIO. Each thread
  * in this pool runs an io_context that allows any part in Broker to post
  * a work to be done.
+ *
+ * This pool may look a little complicated. We can see inside it several
+ * attributes, let's make a quick tour of them. A thread pool is an array of
+ * threads. This array, here, is a std::vector named _pool.
+ *
+ * This pool is instanciated through a unique instance. So its constructor is
+ * private and we have a static method named instance() to get it.
+ *
+ * Before calling the instance of the pool, we can set the number of threads
+ * inside it. This is done with a static member function named set_size(size_t).
+ *
+ * If the set_size() has not been called before using the pool or if the size
+ * has been set to 0, its size will be initialized with the number of cpus on
+ * the host computer.
+ *
+ * To post tasks to the pool, we use the ASIO api, for that we need an
+ * asio::io_context and an asio::io_service::work which are defined when then
+ * pool is constructed.
+ *
+ * There is a _closed boolean variable used internally to know if the pool is
+ * running (and not closed) or stopped (and closed). To work with it, we also
+ * use a mutex _closed_m.
+ *
+ * And to have statistics on that pool, every 10s, we execute a task
+ * _check_latency() whose goal is to measure the duration between the time point
+ * when we ask to execute a task and the time point when we get its execution.
+ * This duration is stored in _latency.
+ *
+ * We can see a steady_timer in the class, its goal is to cadence this check.
  */
 class pool {
   static size_t _pool_size;
@@ -38,9 +67,10 @@ class pool {
   asio::io_service::work _worker;
   std::vector<std::thread> _pool;
   bool _closed;
+  mutable std::mutex _closed_m;
+
   asio::steady_timer _timer;
 
-  mutable std::mutex _closed_m;
   /* Latency in milliseconds between the call of check_latency and its real
    * execution. */
   std::atomic<double> _latency;

--- a/core/inc/com/centreon/broker/pool.hh
+++ b/core/inc/com/centreon/broker/pool.hh
@@ -25,13 +25,25 @@
 
 CCB_BEGIN()
 
+/**
+ * @brief The Broker's thread pool.
+ *
+ * At the origin, this thread pool is configured to be used by ASIO. Each thread
+ * in this pool runs an io_context that allows any part in Broker to post
+ * a work to be done.
+ */
 class pool {
   static size_t _pool_size;
   asio::io_context _io_context;
   asio::io_service::work _worker;
   std::vector<std::thread> _pool;
   bool _closed;
+  asio::steady_timer _timer;
+
   mutable std::mutex _closed_m;
+  /* Latency in milliseconds between the call of check_latency and its real
+   * execution. */
+  std::atomic<uint32_t> _latency;
 
   pool();
   void _start();
@@ -46,6 +58,7 @@ class pool {
   static pool& instance();
   static asio::io_context& io_context();
   size_t get_current_size() const;
+  void check_latency();
 };
 
 CCB_END()

--- a/core/src/main.cc
+++ b/core/src/main.cc
@@ -51,7 +51,7 @@ static std::vector<std::string> gl_mainconfigfiles;
 static config::state gl_state;
 
 static struct option long_options[] = {
-  {"pool-size",   required_argument, 0, 'p'},
+  {"pool_size",   required_argument, 0, 's'},
   {"check",       no_argument,       0, 'c'},
   {"debug",       no_argument,       0, 'd'},
   {"diagnose",    no_argument,       0, 'D'},
@@ -170,7 +170,7 @@ int main(int argc, char* argv[]) {
 
     opt = getopt_long (argc, argv, "p:cdDvh",
                         long_options, &option_index);
-    switch(opt) {
+    switch (opt) {
       case 'p':
         n_thread = atoi(optarg);
         break;
@@ -285,6 +285,11 @@ int main(int argc, char* argv[]) {
           conf.loggers().push_back(default_state.loggers().front());
         }
 
+        if (n_thread > 0 && n_thread < 100) 
+          pool::set_size(n_thread);
+        else 
+          pool::set_size(conf.pool_size());
+
         // Add debug output if in debug mode.
         if (debug)
           conf.loggers().insert(conf.loggers().end(),
@@ -329,11 +334,6 @@ int main(int argc, char* argv[]) {
             rpc->shutdown();
             delete rpc;
           });
-
-      if (n_thread > 0 && n_thread < 100) 
-        pool::set_size(n_thread);
-      else 
-        pool::set_size(gl_state.pool_size());
 
       // Launch event loop.
       if (!check)

--- a/core/src/pool.cc
+++ b/core/src/pool.cc
@@ -25,6 +25,11 @@ using namespace com::centreon::broker;
 
 size_t pool::_pool_size(0);
 
+/**
+ * @brief The way to access to the pool.
+ *
+ * @return a reference to the pool.
+ */
 pool& pool::instance() {
   static pool instance;
   return instance;
@@ -74,6 +79,9 @@ void pool::_start() {
   }
 }
 
+/**
+ * @brief Destructor
+ */
 pool::~pool() noexcept {
   _stop();
 }

--- a/core/src/pool.cc
+++ b/core/src/pool.cc
@@ -17,8 +17,6 @@
 */
 #include "com/centreon/broker/pool.hh"
 
-#include <asio.hpp>
-
 #include "com/centreon/broker/log_v2.hh"
 
 using namespace com::centreon::broker;

--- a/core/src/pool.cc
+++ b/core/src/pool.cc
@@ -15,8 +15,9 @@
 **
 ** For more information : contact@centreon.com
 */
-#include <asio.hpp>
 #include "com/centreon/broker/pool.hh"
+
+#include <asio.hpp>
 
 #include "com/centreon/broker/log_v2.hh"
 
@@ -42,9 +43,13 @@ asio::io_context& pool::io_context() {
  * @brief Default constructor. Hidden, is called throw the static instance()
  * method.
  */
-pool::pool() : _io_context(_pool_size), _worker(_io_context), _closed(true), _timer(_io_context) {
+pool::pool()
+    : _io_context(_pool_size),
+      _worker(_io_context),
+      _closed(true),
+      _timer(_io_context) {
   _start();
-  check_latency();
+  _check_latency();
 }
 
 /**
@@ -109,15 +114,32 @@ size_t pool::get_current_size() const {
   return _pool.size();
 }
 
-void pool::check_latency() {
-  std::chrono::time_point<std::chrono::system_clock> start =
-    std::chrono::system_clock::now();
+/**
+ * @brief The function whose role is to compute the latency. It makes the
+ * computation every 10s.
+ *
+ */
+void pool::_check_latency() {
+  auto start = std::chrono::system_clock::now();
   asio::post(_io_context, [start, this] {
-    std::chrono::time_point<std::chrono::system_clock> end =
-      std::chrono::system_clock::now();
-    _latency = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    auto end = std::chrono::system_clock::now();
+    auto duration = std::chrono::duration<double, std::milli>(end - start);
+    _latency = duration.count();
     log_v2::core()->trace("Thread pool latency at {}ms", _latency);
   });
-  _timer.expires_after(std::chrono::seconds(30));
-  _timer.async_wait(std::bind(&pool::check_latency, this));
+  _timer.expires_after(std::chrono::seconds(10));
+  _timer.async_wait(std::bind(&pool::_check_latency, this));
+}
+
+/**
+ * @brief Get the pool latency in ms. This value is computed
+ * every 10s and represents the duration between the time point we tell the
+ * thread pool to execute a task and the time point when it really executes this
+ * task. A latency of 0ms means the pool has enough free threads to execute
+ * tasks immediatly.
+ *
+ * @return A duration in ms.
+ */
+double pool::get_latency() const {
+  return _latency;
 }


### PR DESCRIPTION
## Description

Broker statistics have a new field containing the number of threads in the pool and also its latency in ms.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Start Broker and look at its statistics.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

