### PR TITLE
Mon 6282 retention too slow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID STREQ
 endif ()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-add_definitions("-D_GLIBCXX_USE_CXX11_ABI=0")
+add_definitions("-D_GLIBCXX_USE_CXX11_ABI=1")
 
 # With ASIO DEBUGGING ENABLED
 option(WITH_DEBUG_ASIO "Add the Asio debugging flags." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID STREQ
 endif ()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-add_definitions("-D_GLIBCXX_USE_CXX11_ABI=1")
+add_definitions("-D_GLIBCXX_USE_CXX11_ABI=0")
 
 # With ASIO DEBUGGING ENABLED
 option(WITH_DEBUG_ASIO "Add the Asio debugging flags." OFF)

--- a/core/inc/com/centreon/broker/file/splitter.hh
+++ b/core/inc/com/centreon/broker/file/splitter.hh
@@ -20,7 +20,9 @@
 #define CCB_FILE_SPLITTER_HH
 
 #include <memory>
+#include <mutex>
 #include <string>
+
 #include "com/centreon/broker/file/fs_file.hh"
 #include "com/centreon/broker/namespace.hh"
 
@@ -35,12 +37,32 @@ namespace file {
  *  provide easier file management.
  */
 class splitter : public fs_file {
+  bool _auto_delete;
+  std::string _base_path;
+  long _max_file_size;
+  std::shared_ptr<FILE> _rfile;
+  std::mutex* _rmutex;
+  int32_t _rid;
+  long _roffset;
+  std::shared_ptr<FILE> _wfile;
+  std::mutex* _wmutex;
+  int32_t _wid;
+  long _woffset;
+  std::mutex _mutex1;
+  std::mutex _mutex2;
+  std::mutex _id_m;
+
+  void _open_read_file();
+  void _open_write_file();
+
  public:
   splitter(std::string const& path,
            fs_file::open_mode mode,
            long max_file_size = 100000000,
            bool auto_delete = false);
   ~splitter();
+  splitter(const splitter&) = delete;
+  splitter& operator=(const splitter&) = delete;
   void close() override;
   long read(void* buffer, long max_size) override;
   void remove_all_files();
@@ -52,26 +74,10 @@ class splitter : public fs_file {
 
   std::string get_file_path(int id = 0) const;
   long get_max_file_size() const;
-  int get_rid() const;
+  int32_t get_rid() const;
   long get_roffset() const;
-  int get_wid() const;
+  int32_t get_wid() const;
   long get_woffset() const;
-
- private:
-  splitter(splitter const& other);
-  splitter& operator=(splitter const& other);
-  void _open_read_file();
-  void _open_write_file();
-
-  bool _auto_delete;
-  std::string _base_path;
-  long _max_file_size;
-  std::shared_ptr<fs_file> _rfile;
-  int _rid;
-  long _roffset;
-  std::shared_ptr<fs_file> _wfile;
-  int _wid;
-  long _woffset;
 };
 }  // namespace file
 

--- a/core/inc/com/centreon/broker/file/stream.hh
+++ b/core/inc/com/centreon/broker/file/stream.hh
@@ -49,7 +49,6 @@ class stream : public io::stream {
  private:
 
   std::unique_ptr<splitter> _file;
-  mutable std::mutex _mutex;
   mutable long long _last_read_offset;
   mutable time_t _last_time;
   mutable long long _last_write_offset;

--- a/core/src/file/stream.cc
+++ b/core/src/file/stream.cc
@@ -67,9 +67,7 @@ std::string stream::peer() const {
 bool stream::read(std::shared_ptr<io::data>& d, time_t deadline) {
   (void)deadline;
 
-  // Lock mutex.
   d.reset();
-  std::lock_guard<std::mutex> lock(_mutex);
 
   // Build data array.
   std::unique_ptr<io::raw> data(new io::raw);
@@ -164,9 +162,6 @@ int stream::write(std::shared_ptr<io::data> const& d) {
     return 1;
 
   if (d->type() == io::raw::static_type()) {
-    // Lock mutex.
-    std::lock_guard<std::mutex> lock(_mutex);
-
     // Get data.
     char const* memory;
     uint32_t size;


### PR DESCRIPTION
## Description

splitter should be much more faster.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x (master)
