### PR TITLE
Mon 6367 ipv4 bad flush 20.04.x

### DIFF
--- a/doc/en/release_notes/broker20.04.rst
+++ b/doc/en/release_notes/broker20.04.rst
@@ -16,6 +16,11 @@ The splitter class is now thread safe and does not need external locks anymore.
 It is also far less strict and allows some reading and some writing at the same
 time.
 
+TCP
+===
+Writing on a tcp stream could slow down in case of many retention files. The
+issue was essentially in the flush internal function.
+
 ************
 Enhancements
 ************

--- a/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
+++ b/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
@@ -39,6 +39,7 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
   std::mutex _exposed_write_queue_m;
   std::queue<std::vector<char>> _exposed_write_queue;
   std::queue<std::vector<char>> _write_queue;
+  std::atomic_bool _write_queue_has_events;
   std::atomic_bool _writing;
 
   std::atomic<int32_t> _acks;
@@ -52,8 +53,6 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
 
   std::atomic_bool _closed;
   std::string _peer;
-
-  std::condition_variable _is_writing_cv;
 
  public:
   typedef std::shared_ptr<tcp_connection> pointer;

--- a/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
+++ b/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
@@ -33,7 +33,7 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
   asio::ip::tcp::socket _socket;
   asio::io_context::strand _strand;
 
-  std::mutex _data_m;
+  std::mutex _error_m;
   asio::error_code _current_error;
 
   std::mutex _exposed_write_queue_m;

--- a/tcp/src/tcp_connection.cc
+++ b/tcp/src/tcp_connection.cc
@@ -95,6 +95,9 @@ int32_t tcp_connection::flush() {
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
+  //FIXME DBR
+  if (_peer.find(":5670") != std::string::npos)
+    log_v2::perfdata()->error("tcp_connection::flush to {} with {} events", _peer, retval);
   return retval;
 }
 
@@ -187,6 +190,11 @@ int32_t tcp_connection::write(const std::vector<char>& v) {
   /* Do not set it to zero directly, maybe it has already been incremented by
    * another operation */
   _acks -= retval;
+
+  //FIXME DBR
+  if (_peer.find(":5670") != std::string::npos)
+    log_v2::perfdata()->error("tcp_connection::write to {} with {} events", _peer, retval);
+
   return retval;
 }
 

--- a/tcp/src/tcp_connection.cc
+++ b/tcp/src/tcp_connection.cc
@@ -80,10 +80,22 @@ asio::ip::tcp::socket& tcp_connection::socket() {
  * @return 0.
  */
 int32_t tcp_connection::flush() {
+  int32_t retval = _acks;
+  if (_acks) {
+    /* Do not set it to zero directly, maybe it has already been incremented by
+     * another operation */
+    _acks -= retval;
+  }
   while (_writing) {
+    if (_acks) {
+      int32_t tmp = _acks;
+      _acks -= tmp;
+      retval += tmp;
+      return retval;
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
-  return 0;
+  return retval;
 }
 
 /**

--- a/tcp/src/tcp_connection.cc
+++ b/tcp/src/tcp_connection.cc
@@ -39,6 +39,7 @@ tcp_connection::tcp_connection(asio::io_context& io_context,
                                uint16_t port)
     : _socket(io_context),
       _strand(io_context),
+      _write_queue_has_events(false),
       _writing(false),
       _acks(0),
       _reading(false),
@@ -85,15 +86,32 @@ int32_t tcp_connection::flush() {
     /* Do not set it to zero directly, maybe it has already been incremented by
      * another operation */
     _acks -= retval;
+    return retval;
+  }
+  {
+    std::lock_guard<std::mutex> lck(_error_m);
+    if (_current_error) {
+      std::string msg{std::move(_current_error.message())};
+      _current_error.clear();
+      throw exceptions::msg() << msg;
+    }
+  }
+  if (_write_queue_has_events && !_writing) {
+    _writing = true;
+    // The strand is useful because of the flush() method.
+    _strand.context().post(std::bind(&tcp_connection::writing, ptr()));
   }
   while (_writing) {
     if (_acks) {
-      int32_t tmp = _acks;
-      _acks -= tmp;
-      retval += tmp;
+      retval = _acks;
+      _acks -= retval;
       return retval;
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    else {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      if (_peer.find(":5670") != std::string::npos)
+        log_v2::perfdata()->error("tcp_connection::flush waiting for 20ms");
+    }
   }
   //FIXME DBR
   if (_peer.find(":5670") != std::string::npos)
@@ -208,11 +226,12 @@ int32_t tcp_connection::write(const std::vector<char>& v) {
  *  * Launches the async_write.
  */
 void tcp_connection::writing() {
-  if (_write_queue.empty()) {
+  if (!_write_queue_has_events) {
     std::lock_guard<std::mutex> lck(_exposed_write_queue_m);
     std::swap(_write_queue, _exposed_write_queue);
+    _write_queue_has_events = !_write_queue.empty();
   }
-  if (_write_queue.empty()) {
+  if (!_write_queue_has_events) {
     _writing = false;
     return;
   }
@@ -237,7 +256,8 @@ void tcp_connection::handle_write(const asio::error_code& ec) {
   } else {
     ++_acks;
     _write_queue.pop();
-    if (!_write_queue.empty()) {
+    _write_queue_has_events = !_write_queue.empty();
+    if (_write_queue_has_events) {
       // The strand is useful because of the flush() method.
       asio::async_write(_socket, asio::buffer(_write_queue.front()),
                         _strand.wrap(std::bind(&tcp_connection::handle_write,

--- a/tcp/src/tcp_connection.cc
+++ b/tcp/src/tcp_connection.cc
@@ -101,21 +101,6 @@ int32_t tcp_connection::flush() {
     // The strand is useful because of the flush() method.
     _strand.context().post(std::bind(&tcp_connection::writing, ptr()));
   }
-//  while (_writing) {
-//    if (_acks) {
-//      retval = _acks;
-//      _acks -= retval;
-//      return retval;
-//    }
-//    else {
-//      std::this_thread::sleep_for(std::chrono::milliseconds(20));
-//      if (_peer.find(":5670") != std::string::npos)
-//        log_v2::perfdata()->error("tcp_connection::flush waiting for 20ms");
-//    }
-//  }
-  //FIXME DBR
-  if (_peer.find(":5670") != std::string::npos)
-    log_v2::perfdata()->error("tcp_connection::flush to {} with {} events", _peer, retval);
   return retval;
 }
 
@@ -208,10 +193,6 @@ int32_t tcp_connection::write(const std::vector<char>& v) {
   /* Do not set it to zero directly, maybe it has already been incremented by
    * another operation */
   _acks -= retval;
-
-  //FIXME DBR
-  if (_peer.find(":5670") != std::string::npos)
-    log_v2::perfdata()->error("tcp_connection::write to {} with {} events", _peer, retval);
 
   return retval;
 }

--- a/tcp/src/tcp_connection.cc
+++ b/tcp/src/tcp_connection.cc
@@ -101,18 +101,18 @@ int32_t tcp_connection::flush() {
     // The strand is useful because of the flush() method.
     _strand.context().post(std::bind(&tcp_connection::writing, ptr()));
   }
-  while (_writing) {
-    if (_acks) {
-      retval = _acks;
-      _acks -= retval;
-      return retval;
-    }
-    else {
-      std::this_thread::sleep_for(std::chrono::milliseconds(20));
-      if (_peer.find(":5670") != std::string::npos)
-        log_v2::perfdata()->error("tcp_connection::flush waiting for 20ms");
-    }
-  }
+//  while (_writing) {
+//    if (_acks) {
+//      retval = _acks;
+//      _acks -= retval;
+//      return retval;
+//    }
+//    else {
+//      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+//      if (_peer.find(":5670") != std::string::npos)
+//        log_v2::perfdata()->error("tcp_connection::flush waiting for 20ms");
+//    }
+//  }
   //FIXME DBR
   if (_peer.find(":5670") != std::string::npos)
     log_v2::perfdata()->error("tcp_connection::flush to {} with {} events", _peer, retval);
@@ -232,6 +232,7 @@ void tcp_connection::writing() {
     _write_queue_has_events = !_write_queue.empty();
   }
   if (!_write_queue_has_events) {
+
     _writing = false;
     return;
   }

--- a/tcp/test/acceptor.cc
+++ b/tcp/test/acceptor.cc
@@ -111,7 +111,8 @@ TEST(TcpAcceptor, Nominal) {
       }
     }
     s_centengine->write(data_write);
-    while (s_centengine->flush() == 0)
+    int retry = 10;
+    while (retry-- && s_centengine->flush() == 0)
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
@@ -159,7 +160,8 @@ TEST(TcpAcceptor, QuestionAnswer) {
       }
       s_cbd->write(data_write);
     }
-    while (s_cbd->flush() == 0)
+    int retry = 10;
+    while (retry-- && s_cbd->flush() == 0)
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
@@ -305,7 +307,8 @@ TEST(TcpAcceptor, MultiNominal) {
         }
       }
       s_centengine->write(data_write);
-      while (s_centengine->flush() == 0)
+      int retry = 10;
+      while (retry-- && s_centengine->flush() == 0)
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
       std::unique_lock<std::mutex> lock(cbd_m);
       cbd_cv.wait(lock, [&cbd_finished] { return cbd_finished; });
@@ -351,7 +354,8 @@ TEST(TcpAcceptor, NominalReversed) {
       }
     }
     s_centengine->write(data_write);
-    while (s_centengine->flush() == 0)
+    int retry = 10;
+    while (retry-- && s_centengine->flush() == 0)
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
@@ -410,7 +414,8 @@ TEST(TcpAcceptor, OnePeer) {
       }
     }
     s_centengine->write(data_write);
-    while (s_centengine->flush() == 0)
+    int retry = 10;
+    while (retry-- && s_centengine->flush() == 0)
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
@@ -505,7 +510,8 @@ TEST(TcpAcceptor, OnePeerReversed) {
       }
     }
     s_centengine->write(data_write);
-    while (s_centengine->flush() == 0)
+    int retry = 10;
+    while (retry-- && s_centengine->flush() == 0)
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
@@ -543,7 +549,8 @@ TEST(TcpAcceptor, MultiOnePeer) {
         std::shared_ptr<io::raw> data_write = std::make_shared<io::raw>();
         data_write->append(std::string("Hello2!"));
         s_centengine->write(data_write);
-        while (s_centengine->flush() == 0)
+        int retry = 10;
+        while (retry-- && s_centengine->flush() == 0)
           std::this_thread::sleep_for(std::chrono::milliseconds(100));
         s_centengine.reset();
         i++;
@@ -628,7 +635,8 @@ TEST(TcpAcceptor, NominalRepeated) {
       std::cout << "engine 4 " << i << "\n";
       i++;
     }
-    while (s_centengine->flush() == 0)
+    int retry = 10;
+    while (retry-- && s_centengine->flush() == 0)
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
@@ -714,7 +722,8 @@ TEST(TcpAcceptor, Simple) {
     std::shared_ptr<io::data> data_read;
     data->append(std::string("TEST\n"));
     str->write(data);
-    while (str->flush() == 0)
+    int retry = 10;
+    while (retry-- && str->flush() == 0)
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     std::unique_lock<std::mutex> lock(m);
     cv.wait(lock, [&finish] { return finish; });
@@ -865,7 +874,8 @@ TEST(TcpAcceptor, CloseRead) {
       std::shared_ptr<io::data> data_read;
       data->append(std::string("0"));
       str->write(data);
-      while (str->flush() == 0)
+      int retry = 10;
+      while (retry-- && str->flush() == 0)
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
   }};
@@ -946,7 +956,8 @@ TEST(TcpAcceptor, QuestionAnswerMultiple) {
         }
         s_cbd->write(data_write);
       }
-      while (s_cbd->flush() == 0)
+      int retry = 10;
+      while (retry-- && s_cbd->flush() == 0)
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     });
 

--- a/tcp/test/acceptor.cc
+++ b/tcp/test/acceptor.cc
@@ -111,7 +111,8 @@ TEST(TcpAcceptor, Nominal) {
       }
     }
     s_centengine->write(data_write);
-    s_centengine->flush();
+    while (s_centengine->flush() == 0)
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
   centengine.join();
@@ -158,7 +159,8 @@ TEST(TcpAcceptor, QuestionAnswer) {
       }
       s_cbd->write(data_write);
     }
-    s_cbd->flush();
+    while (s_cbd->flush() == 0)
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
   std::thread centengine([] {
@@ -303,7 +305,8 @@ TEST(TcpAcceptor, MultiNominal) {
         }
       }
       s_centengine->write(data_write);
-      s_centengine->flush();
+      while (s_centengine->flush() == 0)
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
       std::unique_lock<std::mutex> lock(cbd_m);
       cbd_cv.wait(lock, [&cbd_finished] { return cbd_finished; });
     });
@@ -348,7 +351,8 @@ TEST(TcpAcceptor, NominalReversed) {
       }
     }
     s_centengine->write(data_write);
-    s_centengine->flush();
+    while (s_centengine->flush() == 0)
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -406,7 +410,8 @@ TEST(TcpAcceptor, OnePeer) {
       }
     }
     s_centengine->write(data_write);
-    s_centengine->flush();
+    while (s_centengine->flush() == 0)
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
   std::thread cbd([] {
@@ -500,7 +505,8 @@ TEST(TcpAcceptor, OnePeerReversed) {
       }
     }
     s_centengine->write(data_write);
-    s_centengine->flush();
+    while (s_centengine->flush() == 0)
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
   centengine.join();
@@ -537,7 +543,8 @@ TEST(TcpAcceptor, MultiOnePeer) {
         std::shared_ptr<io::raw> data_write = std::make_shared<io::raw>();
         data_write->append(std::string("Hello2!"));
         s_centengine->write(data_write);
-        s_centengine->flush();
+        while (s_centengine->flush() == 0)
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
         s_centengine.reset();
         i++;
       } else
@@ -621,7 +628,8 @@ TEST(TcpAcceptor, NominalRepeated) {
       std::cout << "engine 4 " << i << "\n";
       i++;
     }
-    s_centengine->flush();
+    while (s_centengine->flush() == 0)
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
 
   /* We start nb_steps instances of cbd one after the other. Each time, it
@@ -706,7 +714,8 @@ TEST(TcpAcceptor, Simple) {
     std::shared_ptr<io::data> data_read;
     data->append(std::string("TEST\n"));
     str->write(data);
-    str->flush();
+    while (str->flush() == 0)
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     std::unique_lock<std::mutex> lock(m);
     cv.wait(lock, [&finish] { return finish; });
   });
@@ -856,7 +865,8 @@ TEST(TcpAcceptor, CloseRead) {
       std::shared_ptr<io::data> data_read;
       data->append(std::string("0"));
       str->write(data);
-      str->flush();
+      while (str->flush() == 0)
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
   }};
   std::shared_ptr<io::stream> io;
@@ -936,7 +946,8 @@ TEST(TcpAcceptor, QuestionAnswerMultiple) {
         }
         s_cbd->write(data_write);
       }
-      s_cbd->flush();
+      while (s_cbd->flush() == 0)
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     });
 
     centengine.emplace_back([i] {


### PR DESCRIPTION
## Description

When there are a lot of RRD retention, Broker can have difficulties to push events to rrd broker.
This patch fixes this issue and several others.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [X] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)
