### PR TITLE
Mon 6397 bam reporting double duration 20.10

### DIFF
--- a/bam/inc/com/centreon/broker/bam/monitoring_stream.hh
+++ b/bam/inc/com/centreon/broker/bam/monitoring_stream.hh
@@ -41,6 +41,20 @@ namespace bam {
  *  metrics table of a centbam DB.
  */
 class monitoring_stream : public io::stream {
+  configuration::applier::state _applier;
+  std::string _status;
+  std::string _ext_cmd_file;
+  ba_svc_mapping _ba_mapping;
+  ba_svc_mapping _meta_mapping;
+  mutable std::mutex _statusm;
+  mysql _mysql;
+  database::mysql_stmt _ba_update;
+  database::mysql_stmt _kpi_update;
+  database::mysql_stmt _meta_service_update;
+  int32_t _pending_events;
+  database_config _storage_db_cfg;
+  std::shared_ptr<persistent_cache> _cache;
+
  public:
   monitoring_stream(std::string const& ext_cmd_file,
                     database_config const& db_cfg,
@@ -65,20 +79,6 @@ class monitoring_stream : public io::stream {
 
   void _read_cache();
   void _write_cache();
-
-  configuration::applier::state _applier;
-  std::string _status;
-  std::string _ext_cmd_file;
-  ba_svc_mapping _ba_mapping;
-  ba_svc_mapping _meta_mapping;
-  mutable std::mutex _statusm;
-  mysql _mysql;
-  database::mysql_stmt _ba_update;
-  database::mysql_stmt _kpi_update;
-  database::mysql_stmt _meta_service_update;
-  int _pending_events;
-  database_config _storage_db_cfg;
-  std::shared_ptr<persistent_cache> _cache;
 };
 }  // namespace bam
 

--- a/bam/src/monitoring_stream.cc
+++ b/bam/src/monitoring_stream.cc
@@ -390,7 +390,7 @@ void monitoring_stream::_rebuild() {
   // Set all the BAs to should not be rebuild.
   {
     std::string query("UPDATE mod_bam SET must_be_rebuild='0'");
-    _mysql.run_query(query, "BAM: could not update the list of BAs to rebuild");
+    _mysql.run_query(query, database::mysql_error::rebuild_ba);
   }
 }
 

--- a/core/inc/com/centreon/broker/database/mysql_error.hh
+++ b/core/inc/com/centreon/broker/database/mysql_error.hh
@@ -19,9 +19,11 @@
 #ifndef CCB_MYSQL_ERROR_HH
 #define CCB_MYSQL_ERROR_HH
 
+#include <fmt/format.h>
+
 #include <atomic>
 #include <string>
-#include <fmt/format.h>
+
 #include "com/centreon/broker/namespace.hh"
 
 CCB_BEGIN()
@@ -35,14 +37,82 @@ namespace database {
  */
 class mysql_error {
  public:
-  mysql_error(): _active(false) {}
+  enum code {
+    empty,
+    clean_hosts_services,
+    clean_hostgroup_members,
+    clean_servicegroup_members,
+    clean_empty_hostgroups,
+    clean_empty_servicegroups,
+    clean_host_dependencies,
+    clean_service_dependencies,
+    clean_host_parents,
+    clean_modules,
+    clean_downtimes,
+    clean_comments,
+    clean_customvariables,
+    restore_instances,
+    update_customvariables,
+    update_logs,
+    update_metrics,
+    insert_data,
+    delete_metric,
+    delete_index,
+    flag_index_data,
+    delete_hosts,
+    delete_modules,
+    update_index_state,
+    delete_availabilities,
+    insert_availability,
+    rebuild_ba,
+    close_event,
+    close_ba_events,
+    close_kpi_events,
+    delete_ba_durations,
+  };
+  static constexpr const char* msg[]{
+      "error: ",
+      "could not clean hosts and services tables: ",
+      "could not clean host groups memberships table: ",
+      "could not clean service groups memberships table: ",
+      "could not remove empty host groups: ",
+      "could not remove empty service groups: ",
+      "could not clean host dependencies table: ",
+      "could not clean service dependencies table: ",
+      "could not clean host parents table: ",
+      "could not clean modules table: ",
+      "could not clean downtimes table: ",
+      "could not clean comments table: ",
+      "could not clean custom variables table: ",
+      "could not restore outdated instance: ",
+      "could not store custom variables correctly: ",
+      "could not store logs correctly: ",
+      "could not update metrics: ",
+      "could not insert data in data_bin: ",
+      "could not delete metric: ",
+      "could not delete index: ",
+      "could not flag the index_data table to delete outdated entries: ",
+      "could not delete outdated entries from the hosts table: ",
+      "could not delete outdated entries from the modules table: ",
+      "cannot update state of index: ",
+      "availability thread could not delete the BA availabilities from the "
+      "reporting database: ",
+      "availability thread could not insert an availability: ",
+      "could not update the list of BAs to rebuild: ",
+      "could not close inconsistent event: ",
+      "could not close all ba events: ",
+      "could not close all kpi events: ",
+      "could not delete BA durations: ",
+  };
+
+  mysql_error() : _active(false) {}
   mysql_error(mysql_error const& other) = delete;
   mysql_error(mysql_error&& other) = delete;
   mysql_error(char const* message) : _message(message), _active(true) {}
   mysql_error& operator=(mysql_error const& other) = delete;
   std::string get_message() { return std::move(_message); }
 
-  template<typename... Args>
+  template <typename... Args>
   void set_message(std::string const& format, const Args&... args) {
     _message = fmt::format(format, args...);
     _active = true;
@@ -54,6 +124,7 @@ class mysql_error {
   std::string _message;
   std::atomic<bool> _active;
 };
+
 }  // namespace database
 
 CCB_END()

--- a/core/inc/com/centreon/broker/database/mysql_task.hh
+++ b/core/inc/com/centreon/broker/database/mysql_task.hh
@@ -90,13 +90,10 @@ class mysql_task_prepare : public mysql_task {
 
 class mysql_task_run : public mysql_task {
  public:
-  mysql_task_run(std::string const& q, std::string const& error_msg, bool fatal)
-      : mysql_task(mysql_task::RUN),
-        query(q),
-        error_msg(error_msg),
-        fatal(fatal) {}
+  mysql_task_run(std::string const& q, mysql_error::code ec, bool fatal)
+      : mysql_task(mysql_task::RUN), query(q), error_code(ec), fatal(fatal) {}
   std::string query;
-  std::string error_msg;
+  mysql_error::code error_code;
   bool fatal;
 };
 

--- a/core/inc/com/centreon/broker/mysql.hh
+++ b/core/inc/com/centreon/broker/mysql.hh
@@ -20,10 +20,12 @@
 
 #include <atomic>
 
+#include "com/centreon/broker/database/mysql_error.hh"
 #include "com/centreon/broker/mysql_connection.hh"
 
 CCB_BEGIN()
 
+using my_error = database::mysql_error;
 /**
  *  @class mysql mysql.hh "com/centreon/broker/storage/mysql.hh"
  *  @brief Class managing the mysql connection
@@ -40,7 +42,7 @@ class mysql {
       mysql_bind_mapping const& bind_mapping = mysql_bind_mapping());
   void commit(int thread_id = -1);
   int run_query(std::string const& query,
-                std::string const& error_msg = "",
+                my_error::code ec = my_error::empty,
                 bool fatal = false,
                 int thread = -1);
   int run_query_and_get_result(std::string const& query,

--- a/core/inc/com/centreon/broker/mysql_connection.hh
+++ b/core/inc/com/centreon/broker/mysql_connection.hh
@@ -34,6 +34,8 @@
 
 CCB_BEGIN()
 
+using my_error = database::mysql_error;
+
 /**
  *  @class mysql_connection mysql_connection.hh
  * "com/centreon/broker/mysql_connection.hh"
@@ -51,9 +53,7 @@ class mysql_connection {
 
   void prepare_query(int id, std::string const& query);
   void commit(std::promise<bool>* promise, std::atomic_int& count);
-  void run_query(std::string const& query,
-                 std::string const& error_msg,
-                 bool fatal);
+  void run_query(std::string const& query, my_error::code ec, bool fatal);
   void run_query_and_get_result(std::string const& query,
                                 std::promise<database::mysql_result>* promise);
   void run_query_and_get_int(std::string const& query,

--- a/core/src/mysql.cc
+++ b/core/src/mysql.cc
@@ -31,9 +31,7 @@ std::once_flag init_flag;
  *  @param[in] db_cfg  Database configuration.
  */
 mysql::mysql(database_config const& db_cfg)
-    : _db_cfg(db_cfg),
-      _pending_queries(0),
-      _current_connection(0) {
+    : _db_cfg(db_cfg), _pending_queries(0), _current_connection(0) {
   mysql_manager& mgr(mysql_manager::instance());
   _connection = mgr.get_connections(db_cfg);
   log_v2::sql()->info("mysql connector configured with {} connection(s)",
@@ -146,7 +144,7 @@ void mysql::_check_errors() {
  * @return The thread id that executed the query.
  */
 int mysql::run_query(std::string const& query,
-                     std::string const& error_msg,
+                     my_error::code ec,
                      bool fatal,
                      int thread_id) {
   _check_errors();
@@ -154,7 +152,7 @@ int mysql::run_query(std::string const& query,
     // Here, we use _current_thread
     thread_id = choose_best_connection(-1);
 
-  _connection[thread_id]->run_query(query, error_msg, fatal);
+  _connection[thread_id]->run_query(query, ec, fatal);
   return thread_id;
 }
 

--- a/core/src/mysql_connection.cc
+++ b/core/src/mysql_connection.cc
@@ -28,6 +28,8 @@
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::database;
 
+constexpr const char* mysql_error::msg[];
+
 const int STR_SIZE = 200;
 const int MAX_ATTEMPTS = 10;
 
@@ -74,8 +76,8 @@ void mysql_connection::_query(mysql_task* t) {
   mysql_task_run* task(static_cast<mysql_task_run*>(t));
   log_v2::sql()->debug("mysql_connection: run query: {}", task->query);
   if (mysql_query(_conn, task->query.c_str())) {
-    std::string err_msg(
-        fmt::format("{} {}", task->error_msg, ::mysql_error(_conn)));
+    const char* m = mysql_error::msg[task->error_code];
+    std::string err_msg(fmt::format("{} {}", m, ::mysql_error(_conn)));
     log_v2::sql()->error("mysql_connection: {}", err_msg);
     if (task->fatal || _server_error(::mysql_errno(_conn)))
       set_error_message(err_msg);
@@ -633,9 +635,9 @@ void mysql_connection::prepare_query(int stmt_id, std::string const& query) {
  *  @param p A pointer to a promise.
  */
 void mysql_connection::run_query(std::string const& query,
-                                 std::string const& error_msg,
+                                 my_error::code ec,
                                  bool fatal) {
-  _push(std::make_shared<mysql_task_run>(query, error_msg, fatal));
+  _push(std::make_shared<mysql_task_run>(query, ec, fatal));
 }
 
 void mysql_connection::run_query_and_get_result(

--- a/doc/en/release_notes/20.10.rst
+++ b/doc/en/release_notes/20.10.rst
@@ -2,6 +2,15 @@
 Centreon Broker 20.10.3
 =======================
 
+****
+Bugs
+****
+
+Bam reporting
+=============
+When availabilities are computed, durations can be doubled. This new version
+fixes this issue.
+
 ***********
 Enhancement
 ***********

--- a/sql/src/cleanup.cc
+++ b/sql/src/cleanup.cc
@@ -23,6 +23,7 @@
 #include <ctime>
 #include <sstream>
 
+#include "com/centreon/broker/database/mysql_error.hh"
 #include "com/centreon/broker/exceptions/msg.hh"
 #include "com/centreon/broker/logging/logging.hh"
 #include "com/centreon/broker/mysql.hh"
@@ -126,21 +127,17 @@ void cleanup::_run() {
         "    ON hosts.instance_id=instances.instance_id"
         "  SET index_data.to_delete=1"
         "  WHERE instances.deleted=1",
-        "SQL: could not flag the index_data table"
-        " to delete outdated entries",
-        false);
+        database::mysql_error::flag_index_data, false);
     ms.run_query(
         "DELETE hosts FROM hosts INNER JOIN instances"
         "  ON hosts.instance_id=instances.instance_id"
         "  WHERE instances.deleted=1",
-        "SQL: could not delete outdated entries from the hosts table", false);
+        database::mysql_error::delete_hosts, false);
     ms.run_query(
         "DELETE modules FROM modules INNER JOIN instances"
         "  ON modules.instance_id=instances.instance_id"
         "  WHERE instances.deleted=1",
-        "SQL: could not delete outdated entries"
-        " from the modules tables",
-        false);
+        database::mysql_error::delete_modules, false);
 
     // Sleep a while.
     time_t target(time(nullptr) + _interval);

--- a/storage/src/rebuilder.cc
+++ b/storage/src/rebuilder.cc
@@ -25,6 +25,7 @@
 #include <ctime>
 #include <sstream>
 
+#include "com/centreon/broker/database/mysql_error.hh"
 #include "com/centreon/broker/exceptions/msg.hh"
 #include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/logging/logging.hh"
@@ -417,7 +418,5 @@ void rebuilder::_set_index_rebuild(mysql& ms, uint32_t index_id, short state) {
   std::string query(
       fmt::format("UPDATE index_data SET must_be_rebuild='{}' WHERE id={}",
                   state, index_id));
-  std::string err_msg(fmt::format(
-      "storage: rebuilder: cannot update state of index {}: ", index_id));
-  ms.run_query(query, err_msg, false);
+  ms.run_query(query, database::mysql_error::update_index_state, false);
 }


### PR DESCRIPTION
## Description

In availabilities computation, durations can be doubled. Here is a fix.
This patch also improves the errors management in the mysql driver. We do not copy anymore error message strings.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [X] 20.10.x
- [ ] 21.04.x (master)
