### PR TITLE
fix(bam): bam reporting may conflict during rebuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 #
 
 # Set necessary settings.
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.4)
 project("Centreon Broker" C CXX)
 if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(FATAL_ERROR "You can build broker with g++ or clang++. CMake will exit.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 #
 
 # Set necessary settings.
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 2.8)
 project("Centreon Broker" C CXX)
 if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(FATAL_ERROR "You can build broker with g++ or clang++. CMake will exit.")

--- a/bam/inc/com/centreon/broker/bam/dimension_timeperiod.hh
+++ b/bam/inc/com/centreon/broker/bam/dimension_timeperiod.hh
@@ -39,16 +39,6 @@ namespace bam {
  */
 class dimension_timeperiod : public io::data {
  public:
-  dimension_timeperiod();
-  ~dimension_timeperiod();
-  dimension_timeperiod(dimension_timeperiod const&);
-  dimension_timeperiod& operator=(dimension_timeperiod const&);
-  bool operator==(dimension_timeperiod const& other) const;
-  constexpr static uint32_t static_type() {
-    return io::events::data_type<io::events::bam,
-                                 bam::de_dimension_timeperiod>::value;
-  }
-
   uint32_t id;
   std::string name;
   std::string monday;
@@ -59,11 +49,18 @@ class dimension_timeperiod : public io::data {
   std::string saturday;
   std::string sunday;
 
+  dimension_timeperiod(uint32_t id, const std::string& name);
+  ~dimension_timeperiod() noexcept = default;
+  dimension_timeperiod(const dimension_timeperiod&) = delete;
+  dimension_timeperiod& operator=(const dimension_timeperiod&) = delete;
+  bool operator==(const dimension_timeperiod&) const = delete;
+  constexpr static uint32_t static_type() {
+    return io::events::data_type<io::events::bam,
+                                 bam::de_dimension_timeperiod>::value;
+  }
+
   static mapping::entry const entries[];
   static io::event_info::event_operations const operations;
-
- private:
-  void _internal_copy(dimension_timeperiod const& other);
 };
 }  // namespace bam
 

--- a/bam/inc/com/centreon/broker/bam/dimension_truncate_table_signal.hh
+++ b/bam/inc/com/centreon/broker/bam/dimension_truncate_table_signal.hh
@@ -40,19 +40,19 @@ namespace bam {
  */
 class dimension_truncate_table_signal : public io::data {
  public:
-  dimension_truncate_table_signal();
+  bool update_started;
+
+  dimension_truncate_table_signal(bool update);
   dimension_truncate_table_signal(const dimension_truncate_table_signal&) =
       delete;
   ~dimension_truncate_table_signal() noexcept = default;
   dimension_truncate_table_signal& operator=(
       const dimension_truncate_table_signal&) = delete;
-  bool operator==(dimension_truncate_table_signal const& other) const;
+  bool operator==(const dimension_truncate_table_signal&) const = delete;
   constexpr static uint32_t static_type() {
     return io::events::data_type<
         io::events::bam, bam::de_dimension_truncate_table_signal>::value;
   }
-
-  bool update_started;
 
   static mapping::entry const entries[];
   static io::event_info::event_operations const operations;

--- a/bam/inc/com/centreon/broker/bam/dimension_truncate_table_signal.hh
+++ b/bam/inc/com/centreon/broker/bam/dimension_truncate_table_signal.hh
@@ -41,10 +41,11 @@ namespace bam {
 class dimension_truncate_table_signal : public io::data {
  public:
   dimension_truncate_table_signal();
-  dimension_truncate_table_signal(dimension_truncate_table_signal const& other);
-  ~dimension_truncate_table_signal();
+  dimension_truncate_table_signal(const dimension_truncate_table_signal&) =
+      delete;
+  ~dimension_truncate_table_signal() noexcept = default;
   dimension_truncate_table_signal& operator=(
-      dimension_truncate_table_signal const& other);
+      const dimension_truncate_table_signal&) = delete;
   bool operator==(dimension_truncate_table_signal const& other) const;
   constexpr static uint32_t static_type() {
     return io::events::data_type<
@@ -55,9 +56,6 @@ class dimension_truncate_table_signal : public io::data {
 
   static mapping::entry const entries[];
   static io::event_info::event_operations const operations;
-
- private:
-  void _internal_copy(dimension_truncate_table_signal const& other);
 };
 }  // namespace bam
 

--- a/bam/inc/com/centreon/broker/bam/reporting_stream.hh
+++ b/bam/inc/com/centreon/broker/bam/reporting_stream.hh
@@ -52,6 +52,40 @@ class dimension_timeperiod_exclusion;
  *  metrics table of a centbam DB.
  */
 class reporting_stream : public io::stream {
+  uint32_t _ack_events;
+  uint32_t _pending_events;
+  uint32_t _queries_per_transaction;
+  std::string _status;
+  mutable std::mutex _statusm;
+  uint32_t _transaction_queries;
+  mysql _mysql;
+  database::mysql_stmt _ba_full_event_insert;
+  database::mysql_stmt _ba_event_update;
+  database::mysql_stmt _ba_duration_event_insert;
+  database::mysql_stmt _ba_duration_event_update;
+  database::mysql_stmt _kpi_full_event_insert;
+  database::mysql_stmt _kpi_event_update;
+  database::mysql_stmt _kpi_event_link;
+  database::mysql_stmt _kpi_event_link_update;
+  database::mysql_stmt _dimension_ba_insert;
+  database::mysql_stmt _dimension_bv_insert;
+  database::mysql_stmt _dimension_ba_bv_relation_insert;
+  database::mysql_stmt _dimension_timeperiod_insert;
+  database::mysql_stmt _dimension_timeperiod_exception_insert;
+  database::mysql_stmt _dimension_timeperiod_exclusion_insert;
+  database::mysql_stmt _dimension_ba_timeperiod_insert;
+  database::mysql_stmt _dimension_kpi_insert;
+  std::vector<database::mysql_stmt> _dimension_truncate_tables;
+  std::unique_ptr<availability_thread> _availabilities;
+
+  // Timeperiods by BAs, with an option is default timeperiod.
+  timeperiod_map _timeperiods;
+
+  std::vector<std::shared_ptr<io::data>> _dimension_data_cache;
+  std::unordered_map<uint32_t, std::map<std::time_t, uint64_t>>
+      _last_inserted_kpi;  // ba_id => <time, row>
+  bool _processing_dimensions;
+
  public:
   reporting_stream(database_config const& db_cfg);
   ~reporting_stream();
@@ -95,39 +129,6 @@ class reporting_stream : public io::stream {
   void _update_status(std::string const& status);
   void _compute_event_durations(std::shared_ptr<ba_event> const& ev,
                                 io::stream* visitor);
-
-  uint32_t _ack_events;
-  uint32_t _pending_events;
-  uint32_t _queries_per_transaction;
-  std::string _status;
-  mutable std::mutex _statusm;
-  uint32_t _transaction_queries;
-  mysql _mysql;
-  database::mysql_stmt _ba_full_event_insert;
-  database::mysql_stmt _ba_event_update;
-  database::mysql_stmt _ba_duration_event_insert;
-  database::mysql_stmt _ba_duration_event_update;
-  database::mysql_stmt _kpi_full_event_insert;
-  database::mysql_stmt _kpi_event_update;
-  database::mysql_stmt _kpi_event_link;
-  database::mysql_stmt _kpi_event_link_update;
-  database::mysql_stmt _dimension_ba_insert;
-  database::mysql_stmt _dimension_bv_insert;
-  database::mysql_stmt _dimension_ba_bv_relation_insert;
-  database::mysql_stmt _dimension_timeperiod_insert;
-  database::mysql_stmt _dimension_timeperiod_exception_insert;
-  database::mysql_stmt _dimension_timeperiod_exclusion_insert;
-  database::mysql_stmt _dimension_ba_timeperiod_insert;
-  database::mysql_stmt _dimension_kpi_insert;
-  std::vector<database::mysql_stmt> _dimension_truncate_tables;
-  std::unique_ptr<availability_thread> _availabilities;
-
-  // Timeperiods by BAs, with an option is default timeperiod.
-  timeperiod_map _timeperiods;
-
-  std::vector<std::shared_ptr<io::data>> _dimension_data_cache;
-  std::unordered_map<uint32_t, std::map<std::time_t, uint64_t>>
-      _last_inserted_kpi;  // ba_id => <time, row>
 };
 }  // namespace bam
 

--- a/bam/inc/com/centreon/broker/bam/reporting_stream.hh
+++ b/bam/inc/com/centreon/broker/bam/reporting_stream.hh
@@ -111,8 +111,6 @@ class reporting_stream : public io::stream {
   void _process_kpi_event(std::shared_ptr<io::data> const& e);
   void _process_dimension(std::shared_ptr<io::data> const& e);
   void _dimension_dispatch(std::shared_ptr<io::data> const& e);
-  // std::shared_ptr<io::data> _dimension_copy(std::shared_ptr<io::data> const&
-  // e);
   void _process_dimension_ba(std::shared_ptr<io::data> const& e);
   void _process_dimension_bv(std::shared_ptr<io::data> const& e);
   void _process_dimension_ba_bv_relation(std::shared_ptr<io::data> const& e);

--- a/bam/inc/com/centreon/broker/bam/reporting_stream.hh
+++ b/bam/inc/com/centreon/broker/bam/reporting_stream.hh
@@ -77,7 +77,8 @@ class reporting_stream : public io::stream {
   void _process_kpi_event(std::shared_ptr<io::data> const& e);
   void _process_dimension(std::shared_ptr<io::data> const& e);
   void _dimension_dispatch(std::shared_ptr<io::data> const& e);
-  std::shared_ptr<io::data> _dimension_copy(std::shared_ptr<io::data> const& e);
+  // std::shared_ptr<io::data> _dimension_copy(std::shared_ptr<io::data> const&
+  // e);
   void _process_dimension_ba(std::shared_ptr<io::data> const& e);
   void _process_dimension_bv(std::shared_ptr<io::data> const& e);
   void _process_dimension_ba_bv_relation(std::shared_ptr<io::data> const& e);

--- a/bam/src/configuration/reader_v2.cc
+++ b/bam/src/configuration/reader_v2.cc
@@ -567,9 +567,7 @@ void reader_v2::_load_dimensions() {
   // we cache the data until we are sure we have all the data
   // needed from the database.
   std::vector<std::shared_ptr<io::data> > datas;
-  std::shared_ptr<dimension_truncate_table_signal> dtts(
-      new dimension_truncate_table_signal);
-  dtts->update_started = true;
+  auto dtts(std::make_shared<dimension_truncate_table_signal>(true));
   datas.push_back(dtts);
 
   // Load the dimensions.
@@ -815,9 +813,7 @@ void reader_v2::_load_dimensions() {
     }
 
     // End the update.
-    dtts = std::shared_ptr<dimension_truncate_table_signal>(
-        new dimension_truncate_table_signal);
-    dtts->update_started = false;
+    dtts = std::make_shared<dimension_truncate_table_signal>(false);
     datas.push_back(dtts);
 
     // Write all the cached data to the publisher.

--- a/bam/src/configuration/reader_v2.cc
+++ b/bam/src/configuration/reader_v2.cc
@@ -635,7 +635,7 @@ void reader_v2::_load_dimensions() {
         ba->sla_month_percent_crit = res.value_as_f64(4);
         ba->sla_duration_warn = res.value_as_i32(5);
         ba->sla_duration_crit = res.value_as_i32(6);
-        datas.push_back(std::static_pointer_cast<io::data>(ba));
+        datas.push_back(ba);
         bas[ba->ba_id] = ba;
         if (!res.value_is_null(7)) {
           std::shared_ptr<dimension_ba_timeperiod_relation> dbtr(
@@ -663,7 +663,7 @@ void reader_v2::_load_dimensions() {
         bv->bv_id = res.value_as_u32(0);
         bv->bv_name = res.value_as_str(1);
         bv->bv_description = res.value_as_str(2);
-        datas.push_back(std::static_pointer_cast<io::data>(bv));
+        datas.push_back(bv);
       }
     } catch (std::exception const& e) {
       throw exceptions::msg()
@@ -690,7 +690,7 @@ void reader_v2::_load_dimensions() {
               new dimension_ba_bv_relation_event);
           babv->ba_id = res.value_as_u32(0);
           babv->bv_id = res.value_as_u32(1);
-          datas.push_back(std::static_pointer_cast<io::data>(babv));
+          datas.push_back(babv);
         }
       } catch (std::exception const& e) {
         throw exceptions::msg()
@@ -751,7 +751,7 @@ void reader_v2::_load_dimensions() {
         database::mysql_result res(promise.get_future().get());
 
         while (_mysql.fetch_row(res)) {
-          std::shared_ptr<dimension_kpi_event> k(new dimension_kpi_event);
+          auto k(std::make_shared<dimension_kpi_event>());
           k->kpi_id = res.value_as_u32(0);
           k->host_id = res.value_as_u32(2);
           k->service_id = res.value_as_u32(3);
@@ -782,7 +782,7 @@ void reader_v2::_load_dimensions() {
             }
             k->kpi_ba_name = found->second->ba_name;
           }
-          datas.push_back(std::static_pointer_cast<io::data>(k));
+          datas.push_back(k);
         }
       } catch (std::exception const& e) {
         throw exceptions::msg()

--- a/bam/src/dimension_timeperiod.cc
+++ b/bam/src/dimension_timeperiod.cc
@@ -26,77 +26,8 @@ using namespace com::centreon::broker::bam;
 /**
  *  Default constructor.
  */
-dimension_timeperiod::dimension_timeperiod()
-    : io::data(dimension_timeperiod::static_type()) {}
-
-/**
- *  Copy constructor.
- *
- *  @param[in] other  Object to copy.
- */
-dimension_timeperiod::dimension_timeperiod(dimension_timeperiod const& other)
-    : io::data(other) {
-  _internal_copy(other);
-}
-
-/**
- *  Destructor.
- */
-dimension_timeperiod::~dimension_timeperiod() {}
-
-/**
- *  Assignment operator.
- *
- *  @param[in] other  Object to copy.
- *
- *  @return This object.
- */
-dimension_timeperiod& dimension_timeperiod::operator=(
-    dimension_timeperiod const& other) {
-  if (this != &other) {
-    io::data::operator=(other);
-    _internal_copy(other);
-  }
-  return *this;
-}
-
-/**
- *  Equality test operator.
- *
- *  @param[in] other  The object to test for equality.
- *
- *  @return  True if the two objects are equal.
- */
-bool dimension_timeperiod::operator==(dimension_timeperiod const& other) const {
-  return ((id == other.id) && (name == other.name) &&
-          (monday == other.monday) && (tuesday == other.tuesday) &&
-          (wednesday == other.wednesday) && (thursday == other.thursday) &&
-          (friday == other.friday) && (saturday == other.saturday) &&
-          (sunday == other.sunday));
-}
-
-/**
- *  Copy internal data members.
- *
- *  @param[in] other Object to copy.
- */
-void dimension_timeperiod::_internal_copy(dimension_timeperiod const& other) {
-  id = other.id;
-  name = other.name;
-  monday = other.monday;
-  tuesday = other.tuesday;
-  wednesday = other.wednesday;
-  thursday = other.thursday;
-  friday = other.friday;
-  saturday = other.saturday;
-  sunday = other.sunday;
-}
-
-/**************************************
- *                                     *
- *           Static Objects            *
- *                                     *
- **************************************/
+dimension_timeperiod::dimension_timeperiod(uint32_t id, const std::string& name)
+    : io::data(dimension_timeperiod::static_type()), id(id), name(name) {}
 
 // Mapping.
 mapping::entry const dimension_timeperiod::entries[] = {
@@ -139,7 +70,7 @@ mapping::entry const dimension_timeperiod::entries[] = {
 
 // Operations.
 static io::data* new_dimension_timeperiod() {
-  return new dimension_timeperiod;
+  return new dimension_timeperiod(0, "");
 }
 io::event_info::event_operations const dimension_timeperiod::operations = {
     &new_dimension_timeperiod};

--- a/bam/src/dimension_truncate_table_signal.cc
+++ b/bam/src/dimension_truncate_table_signal.cc
@@ -24,9 +24,9 @@ using namespace com::centreon::broker::bam;
 /**
  *  Default constructor.
  */
-dimension_truncate_table_signal::dimension_truncate_table_signal()
+dimension_truncate_table_signal::dimension_truncate_table_signal(bool update)
     : io::data(dimension_truncate_table_signal::static_type()),
-      update_started(true) {}
+      update_started(update) {}
 
 /**
  *  Equality test operator.
@@ -35,10 +35,10 @@ dimension_truncate_table_signal::dimension_truncate_table_signal()
  *
  *  @return  True if the two objects are equal.
  */
-bool dimension_truncate_table_signal::operator==(
-    dimension_truncate_table_signal const& other) const {
-  return update_started == other.update_started;
-}
+// bool dimension_truncate_table_signal::operator==(
+//    dimension_truncate_table_signal const& other) const {
+//  return update_started == other.update_started;
+//}
 
 // Mapping.
 mapping::entry const dimension_truncate_table_signal::entries[] = {
@@ -48,7 +48,7 @@ mapping::entry const dimension_truncate_table_signal::entries[] = {
 
 // Operations.
 static io::data* new_dimension_truncate_table_signal() {
-  return new dimension_truncate_table_signal;
+  return new dimension_truncate_table_signal(true);
 }
 io::event_info::event_operations const
     dimension_truncate_table_signal::operations = {

--- a/bam/src/dimension_truncate_table_signal.cc
+++ b/bam/src/dimension_truncate_table_signal.cc
@@ -1,5 +1,5 @@
 /*
-** Copyright 2014-2015 Centreon
+** Copyright 2014-2020 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -29,38 +29,6 @@ dimension_truncate_table_signal::dimension_truncate_table_signal()
       update_started(true) {}
 
 /**
- *  Copy constructor.
- *
- *  @param[in] other  Object to copy.
- */
-dimension_truncate_table_signal::dimension_truncate_table_signal(
-    dimension_truncate_table_signal const& other)
-    : io::data(other) {
-  _internal_copy(other);
-}
-
-/**
- *  Destructor.
- */
-dimension_truncate_table_signal::~dimension_truncate_table_signal() {}
-
-/**
- *  Assignment operator.
- *
- *  @param[in] other  Object to copy.
- *
- *  @return This object.
- */
-dimension_truncate_table_signal& dimension_truncate_table_signal::operator=(
-    dimension_truncate_table_signal const& other) {
-  if (this != &other) {
-    io::data::operator=(other);
-    _internal_copy(other);
-  }
-  return *this;
-}
-
-/**
  *  Equality test operator.
  *
  *  @param[in] other  The object to test for equality.
@@ -71,22 +39,6 @@ bool dimension_truncate_table_signal::operator==(
     dimension_truncate_table_signal const& other) const {
   return update_started == other.update_started;
 }
-
-/**
- *  Copy internal data members.
- *
- *  @param[in] other Object to copy.
- */
-void dimension_truncate_table_signal::_internal_copy(
-    dimension_truncate_table_signal const& other) {
-  update_started = other.update_started;
-}
-
-/**************************************
- *                                     *
- *           Static Objects            *
- *                                     *
- **************************************/
 
 // Mapping.
 mapping::entry const dimension_truncate_table_signal::entries[] = {

--- a/bam/src/dimension_truncate_table_signal.cc
+++ b/bam/src/dimension_truncate_table_signal.cc
@@ -28,18 +28,6 @@ dimension_truncate_table_signal::dimension_truncate_table_signal(bool update)
     : io::data(dimension_truncate_table_signal::static_type()),
       update_started(update) {}
 
-/**
- *  Equality test operator.
- *
- *  @param[in] other  The object to test for equality.
- *
- *  @return  True if the two objects are equal.
- */
-// bool dimension_truncate_table_signal::operator==(
-//    dimension_truncate_table_signal const& other) const {
-//  return update_started == other.update_started;
-//}
-
 // Mapping.
 mapping::entry const dimension_truncate_table_signal::entries[] = {
     mapping::entry(&bam::dimension_truncate_table_signal::update_started,

--- a/bam/src/reporting_stream.cc
+++ b/bam/src/reporting_stream.cc
@@ -187,6 +187,7 @@ int reporting_stream::write(std::shared_ptr<io::data> const& data) {
  *  @param[in] tp  Timeperiod declaration.
  */
 void reporting_stream::_apply(dimension_timeperiod const& tp) {
+  log_v2::bam()->trace("BAM-BI: adding timeperiod {} to cache", tp.id);
   _timeperiods.add_timeperiod(
       tp.id, time::timeperiod::ptr(new time::timeperiod(
                  tp.id, tp.name, "", tp.sunday, tp.monday, tp.tuesday,
@@ -1050,7 +1051,6 @@ void reporting_stream::_process_dimension_truncate_signal(
     log_v2::bam()->debug(
         "BAM-BI: processing table truncation signal (opening)");
 
-    _timeperiods.clear();
     _dimension_data_cache.clear();
   } else {
     log_v2::bam()->debug(
@@ -1061,6 +1061,7 @@ void reporting_stream::_process_dimension_truncate_signal(
     for (auto& stmt : _dimension_truncate_tables)
       _mysql.run_statement(stmt,
                            database::mysql_error::truncate_dimension_table);
+    _timeperiods.clear();
 
     // XXX : dimension event acknowledgement might not work !!!
     //       For this reason, ignore any db error. We wouldn't

--- a/bam/src/reporting_stream.cc
+++ b/bam/src/reporting_stream.cc
@@ -984,59 +984,6 @@ void reporting_stream::_dimension_dispatch(
 }
 
 /**
- *  Copy a dimension event.
- *
- *  @param[in] data  The data to copy.
- *
- *  @return  The dimension event copied.
- */
-// std::shared_ptr<io::data> reporting_stream::_dimension_copy(
-//    std::shared_ptr<io::data> const& data) {
-//  switch (data->type()) {
-//    case io::events::data_type<io::events::bam,
-//                               bam::de_dimension_ba_event>::value:
-//      return std::make_shared<bam::dimension_ba_event>(
-//          *std::static_pointer_cast<bam::dimension_ba_event>(data));
-//    case io::events::data_type<io::events::bam,
-//                               bam::de_dimension_bv_event>::value:
-//      return std::make_shared<bam::dimension_bv_event>(
-//          *std::static_pointer_cast<bam::dimension_bv_event>(data));
-//    case io::events::data_type<io::events::bam,
-//                               bam::de_dimension_ba_bv_relation_event>::value:
-//      return std::make_shared<bam::dimension_ba_bv_relation_event>(
-//          *std::static_pointer_cast<bam::dimension_ba_bv_relation_event>(data));
-//    case io::events::data_type<io::events::bam,
-//                               bam::de_dimension_kpi_event>::value:
-//      return std::make_shared<bam::dimension_kpi_event>(
-//          *std::static_pointer_cast<bam::dimension_kpi_event>(data));
-//    case io::events::data_type<io::events::bam,
-//                               bam::de_dimension_truncate_table_signal>::value:
-//      return std::make_shared<bam::dimension_truncate_table_signal>(
-//          *std::static_pointer_cast<bam::dimension_truncate_table_signal>(
-//              data));
-//    case io::events::data_type<io::events::bam,
-//                               bam::de_dimension_timeperiod>::value:
-//      return std::make_shared<bam::dimension_timeperiod>(
-//          *std::static_pointer_cast<bam::dimension_timeperiod>(data));
-//    case io::events::data_type<io::events::bam,
-//                               bam::de_dimension_timeperiod_exception>::value:
-//      return std::make_shared<bam::dimension_timeperiod_exception>(
-//          *std::static_pointer_cast<bam::dimension_timeperiod_exception>(data));
-//    case io::events::data_type<io::events::bam,
-//                               bam::de_dimension_timeperiod_exclusion>::value:
-//      return std::make_shared<bam::dimension_timeperiod_exclusion>(
-//          *std::static_pointer_cast<bam::dimension_timeperiod_exclusion>(data));
-//    case io::events::data_type<io::events::bam,
-//                               bam::de_dimension_ba_timeperiod_relation>::value:
-//      return std::make_shared<bam::dimension_ba_timeperiod_relation>(
-//          *std::static_pointer_cast<bam::dimension_ba_timeperiod_relation>(
-//              data));
-//    default:
-//      return std::shared_ptr<io::data>();
-//  }
-//}
-
-/**
  *  Process a dimension truncate signal and write it to the db.
  *
  *  @param[in] e The event.

--- a/bam/src/reporting_stream.cc
+++ b/bam/src/reporting_stream.cc
@@ -54,7 +54,8 @@ using namespace com::centreon::broker::database;
  *  @param[in] db_cfg                  BAM DB configuration.
  */
 reporting_stream::reporting_stream(database_config const& db_cfg)
-    : io::stream("BAM-BI"), _ack_events(0), _pending_events(0), _mysql(db_cfg) {
+    : io::stream("BAM-BI"), _ack_events(0), _pending_events(0), _mysql(db_cfg),
+      _processing_dimensions(false) {
   // Prepare queries.
   _prepare();
 

--- a/bam/src/reporting_stream.cc
+++ b/bam/src/reporting_stream.cc
@@ -967,7 +967,8 @@ void reporting_stream::_process_dimension_truncate_signal(
 
   if (dtts.update_started) {
     _processing_dimensions = true;
-    log_v2::bam()->debug("BAM-BI: processing table truncation signal");
+    log_v2::bam()->debug(
+        "BAM-BI: processing table truncation signal (opening)");
 
     for (auto& stmt : _dimension_truncate_tables)
       _mysql.run_statement(stmt,
@@ -976,6 +977,8 @@ void reporting_stream::_process_dimension_truncate_signal(
     _timeperiods.clear();
     _dimension_data_cache.clear();
   } else {
+    log_v2::bam()->debug(
+        "BAM-BI: processing table truncation signal (closing)");
     // Lock the availability thread.
     std::lock_guard<availability_thread> lock(*_availabilities);
 


### PR DESCRIPTION
## Description

There were two bugs here :
* a mutex lock misplaced, so we truncated a table used by another thread at the same time.
* When reporting is rebuilt, if a query fails, all the following are were not executed.

REFS: MON-6397

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x (master)
