### PR TITLE
fix(bam): bam reporting conflicts 19.10

### DIFF
--- a/bam/inc/com/centreon/broker/bam/dimension_truncate_table_signal.hh
+++ b/bam/inc/com/centreon/broker/bam/dimension_truncate_table_signal.hh
@@ -37,13 +37,13 @@ namespace                bam {
    */
   class                  dimension_truncate_table_signal : public io::data {
   public:
-                         dimension_truncate_table_signal();
+                         dimension_truncate_table_signal(bool update);
                          dimension_truncate_table_signal(
-                           dimension_truncate_table_signal const& other);
-                         ~dimension_truncate_table_signal();
+                           dimension_truncate_table_signal const&) = delete;
+                         ~dimension_truncate_table_signal() noexcept = default;
     dimension_truncate_table_signal&
                          operator=(
-                           dimension_truncate_table_signal const& other);
+                           dimension_truncate_table_signal const&) = delete;
     bool                 operator==(
                            dimension_truncate_table_signal const& other) const;
     unsigned int         type() const;
@@ -55,10 +55,6 @@ namespace                bam {
                          entries[];
     static io::event_info::event_operations const
                          operations;
-
-  private:
-    void                 _internal_copy(
-                           dimension_truncate_table_signal const& other);
   };
 }
 

--- a/bam/inc/com/centreon/broker/bam/reporting_stream.hh
+++ b/bam/inc/com/centreon/broker/bam/reporting_stream.hh
@@ -82,8 +82,6 @@ namespace          bam {
     void           _process_kpi_event(std::shared_ptr<io::data> const& e);
     void           _process_dimension(std::shared_ptr<io::data> const& e);
     void           _dimension_dispatch(std::shared_ptr<io::data> const& e);
-    std::shared_ptr<io::data>
-                   _dimension_copy(std::shared_ptr<io::data> const& e);
     void           _process_dimension_ba(std::shared_ptr<io::data> const& e);
     void           _process_dimension_bv(std::shared_ptr<io::data> const& e);
     void           _process_dimension_ba_bv_relation(std::shared_ptr<io::data> const& e);
@@ -132,6 +130,7 @@ namespace          bam {
                    _dimension_data_cache;
 
     std::unordered_map<uint32_t , std::map<std::time_t, quint64>> _last_inserted_kpi;// ba_id => <time, row>
+    bool _processing_dimensions;
   };
 }
 

--- a/bam/src/availability_thread.cc
+++ b/bam/src/availability_thread.cc
@@ -259,7 +259,7 @@ void availability_thread::_build_daily_availabilities(
            "       a.timeperiod_is_default, b.status, b.in_downtime"
            "  FROM mod_bam_reporting_ba_events_durations AS a"
            "    INNER JOIN mod_bam_reporting_ba_events AS b"
-           "  ON a.ba_event_id = b.ba_event_id"
+           "  ON a.ba_event_id = b.ba_event_id AND b.end_time IS NOT NULL"
            "  WHERE ";
   if (_should_rebuild_all)
     query << "(b.ba_id IN (" << _bas_to_rebuild.toStdString() << ")) AND ";

--- a/bam/src/configuration/reader.cc
+++ b/bam/src/configuration/reader.cc
@@ -720,9 +720,7 @@ void reader::_load_dimensions() {
   // we cache the data until we are sure we have all the data
   // needed from the database.
   std::vector<std::shared_ptr<io::data> > datas;
-  std::shared_ptr<dimension_truncate_table_signal> dtts(
-                      new dimension_truncate_table_signal);
-  dtts->update_started = true;
+  auto dtts(std::make_shared<dimension_truncate_table_signal>(true));
   datas.push_back(dtts);
 
   // Get the data from the DB.
@@ -996,8 +994,7 @@ void reader::_load_dimensions() {
     }
 
     // End the update.
-    dtts = std::shared_ptr<dimension_truncate_table_signal>(
-             new dimension_truncate_table_signal);
+    dtts = std::make_shared<dimension_truncate_table_signal>(false);
     dtts->update_started = false;
     datas.push_back(dtts);
 
@@ -1017,6 +1014,4 @@ void reader::_load_dimensions() {
     throw (reader_exception()
            << "BAM: could not load some dimension table: " << e.what());
   }
-
-  return ;
 }

--- a/bam/src/configuration/reader_v2.cc
+++ b/bam/src/configuration/reader_v2.cc
@@ -595,9 +595,7 @@ void reader_v2::_load_dimensions() {
   // we cache the data until we are sure we have all the data
   // needed from the database.
   std::vector<std::shared_ptr<io::data> > datas;
-  std::shared_ptr<dimension_truncate_table_signal> dtts(
-                      new dimension_truncate_table_signal);
-  dtts->update_started = true;
+  auto dtts(std::make_shared<dimension_truncate_table_signal>(true));
   datas.push_back(dtts);
 
   // Get the data from the DB.
@@ -859,9 +857,7 @@ void reader_v2::_load_dimensions() {
     }
 
     // End the update.
-    dtts = std::shared_ptr<dimension_truncate_table_signal>(
-             new dimension_truncate_table_signal);
-    dtts->update_started = false;
+    dtts = std::make_shared<dimension_truncate_table_signal>(false);
     datas.push_back(dtts);
 
     // Write all the cached data to the publisher.

--- a/bam/src/dimension_truncate_table_signal.cc
+++ b/bam/src/dimension_truncate_table_signal.cc
@@ -24,42 +24,13 @@ using namespace com::centreon::broker;
 using namespace com::centreon::broker::bam;
 
 /**
- *  Default constructor.
- */
-dimension_truncate_table_signal::dimension_truncate_table_signal()
-  : update_started(true) {}
-
-/**
- *  Copy constructor.
+ *  Constructor.
  *
- *  @param[in] other  Object to copy.
+ *  @param update: Are we opening the dimension construction or closing it? true for opening, false
+ *  otherwise.
  */
-dimension_truncate_table_signal::dimension_truncate_table_signal(
-    dimension_truncate_table_signal const& other)
-  : io::data(other) {
-  _internal_copy(other);
-}
-
-/**
- *  Destructor.
- */
-dimension_truncate_table_signal::~dimension_truncate_table_signal() {}
-
-/**
- *  Assignment operator.
- *
- *  @param[in] other  Object to copy.
- *
- *  @return This object.
- */
-dimension_truncate_table_signal& dimension_truncate_table_signal::operator=(
-                                                                    dimension_truncate_table_signal const& other) {
-  if (this != &other) {
-    io::data::operator=(other);
-    _internal_copy(other);
-  }
-  return (*this);
-}
+dimension_truncate_table_signal::dimension_truncate_table_signal(bool update)
+  : update_started(update) {}
 
 /**
  *  Equality test operator.
@@ -92,23 +63,6 @@ unsigned int dimension_truncate_table_signal::static_type() {
                                 bam::de_dimension_truncate_table_signal>::value);
 }
 
-/**
- *  Copy internal data members.
- *
- *  @param[in] other Object to copy.
- */
-void dimension_truncate_table_signal::_internal_copy(
-    dimension_truncate_table_signal const& other) {
-  update_started = other.update_started;
-  return ;
-}
-
-/**************************************
-*                                     *
-*           Static Objects            *
-*                                     *
-**************************************/
-
 // Mapping.
 mapping::entry const dimension_truncate_table_signal::entries[] = {
   mapping::entry(
@@ -119,7 +73,7 @@ mapping::entry const dimension_truncate_table_signal::entries[] = {
 
 // Operations.
 static io::data* new_dimension_truncate_table_signal() {
-  return (new dimension_truncate_table_signal);
+  return new dimension_truncate_table_signal(true);
 }
 io::event_info::event_operations const dimension_truncate_table_signal::operations = {
   &new_dimension_truncate_table_signal


### PR DESCRIPTION
## Description

Bam reporting durations can be doubled, this is fixed.
Database error management is improved so that when a query fails, it has a minimal impact on the following ones.

REFS: MON-6397

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)
