### PR TITLE
Mon 6506 comments deadlock 20.10

### DIFF
--- a/doc/en/release_notes/20.10.rst
+++ b/doc/en/release_notes/20.10.rst
@@ -6,6 +6,11 @@ Centreon Broker 20.10.3
 Bugs
 ****
 
+Conflict manager and comments
+=============================
+It is possible to lock the database during comments insertion. This new version
+fixes that.
+
 Bam reporting dimensions computation
 ====================================
 If there are retention files, dimensions computation could fail because of

--- a/storage/src/conflict_manager_sql.cc
+++ b/storage/src/conflict_manager_sql.cc
@@ -395,7 +395,7 @@ void conflict_manager::_process_comment(
   auto& d = std::get<0>(t);
   _finish_action(-1, actions::hosts | actions::instances |
                          actions::host_parents | actions::host_dependencies |
-                         actions::service_dependencies);
+                         actions::service_dependencies | actions::comments);
 
   // Cast object.
   neb::comment const& cmmnt{*static_cast<neb::comment const*>(d.get())};
@@ -422,6 +422,7 @@ void conflict_manager::_process_comment(
   _comment_insupdate << cmmnt;
   _mysql.run_statement(_comment_insupdate, database::mysql_error::store_comment,
                        true, conn);
+  _add_action(conn, actions::comments);
   *std::get<2>(t) = true;
 }
 


### PR DESCRIPTION
## Description

Database centreon_storage can deadlock during comments insertion. This patch should fix this issue.

**Fixes** # (issue)

REFS: MON-6506

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [X] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)
