### PR TITLE
fix(processing): acceptor should not wait too long if a connection is available 20.04

### DIFF
--- a/core/src/processing/acceptor.cc
+++ b/core/src/processing/acceptor.cc
@@ -212,7 +212,7 @@ void acceptor::_callback() noexcept {
           << "acceptor: endpoint '" << _name << "' will wait "
           << _retry_interval << "s before attempting to accept a new client";
       time_t limit{time(nullptr) + _retry_interval};
-      while (!_should_exit && time(nullptr) < limit) {
+      while (!_endp->is_ready() && !_should_exit && time(nullptr) < limit) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
       }
     }

--- a/doc/en/release_notes/broker20.04.rst
+++ b/doc/en/release_notes/broker20.04.rst
@@ -24,7 +24,9 @@ fixes this issue.
 
 Tcp connections
 ===============
-A keep alive is added on acceptor side sockets.
+If the connection between two peers is flapping, it could be difficult for one
+to reconnect to the other and this could lead to many CLOSE_WAIT on the
+acceptor side.
 
 ************
 Enhancements

--- a/doc/en/release_notes/broker20.04.rst
+++ b/doc/en/release_notes/broker20.04.rst
@@ -22,6 +22,10 @@ Bam reporting durations
 When availabilities are computed, durations can be doubled. This new version
 fixes this issue.
 
+Tcp connections
+===============
+A keep alive is added on acceptor side sockets.
+
 ************
 Enhancements
 ************

--- a/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
+++ b/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
@@ -30,10 +30,6 @@ CCB_BEGIN()
 namespace tcp {
 
 class tcp_async {
-  std::mutex _m_read_data;
-  std::mutex _closed_m;
-  bool _closed;
-
   /* The acceptors open by this tcp_async */
   std::list<std::shared_ptr<asio::ip::tcp::acceptor>> _acceptor;
 
@@ -43,12 +39,14 @@ class tcp_async {
   std::unordered_multimap<asio::ip::tcp::acceptor*, tcp_connection::pointer>
       _acceptor_available_con;
 
-  tcp_async();
-  ~tcp_async();
-  void _start();
-  void _stop();
+  tcp_async() = default;
+  ~tcp_async() noexcept = default;
 
  public:
+  static tcp_async& instance();
+
+  tcp_async(const tcp_async&) = delete;
+  tcp_async& operator=(const tcp_async&) = delete;
   std::shared_ptr<asio::ip::tcp::acceptor> create_acceptor(uint16_t port);
   void start_acceptor(std::shared_ptr<asio::ip::tcp::acceptor> acceptor);
   void stop_acceptor(std::shared_ptr<asio::ip::tcp::acceptor> acceptor);
@@ -64,8 +62,6 @@ class tcp_async {
       uint32_t timeout_s);
   bool contains_available_acceptor_connections(
       asio::ip::tcp::acceptor* acceptor) const;
-
-  static tcp_async& instance();
 };
 }  // namespace tcp
 

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -37,42 +37,6 @@ tcp_async& tcp_async::instance() {
 }
 
 /**
- * @brief tcp_aysnc constructor. It is private and should not be called
- * directly.
- */
-tcp_async::tcp_async() : _closed{true} {
-  _start();
-}
-
-/**
- * @brief Start the thread pool used for the tcp connections.
- *
- */
-void tcp_async::_start() {
-  std::lock_guard<std::mutex> lock(_closed_m);
-  if (_closed)
-    _closed = false;
-}
-
-/**
- * @brief Stop the thread pool.
- */
-void tcp_async::_stop() {
-  std::lock_guard<std::mutex> lock(_closed_m);
-  if (!_closed) {
-    _closed = true;
-    // FIXME DBR: We must wait for the pool to be stopped.
-  }
-}
-
-/**
- * @brief tcp_async destructor.
- */
-tcp_async::~tcp_async() {
-  _stop();
-}
-
-/**
  * @brief If the acceptor given in parameter has established a connection.
  * This method returns it. Otherwise, it returns an empty connection.
  *
@@ -132,9 +96,6 @@ std::shared_ptr<asio::ip::tcp::acceptor> tcp_async::create_acceptor(
  */
 void tcp_async::start_acceptor(
     std::shared_ptr<asio::ip::tcp::acceptor> acceptor) {
-  std::lock_guard<std::mutex> lock(_closed_m);
-  if (_closed)
-    return;
 
   tcp_connection::pointer new_connection =
       std::make_shared<tcp_connection>(pool::io_context());
@@ -151,8 +112,6 @@ void tcp_async::start_acceptor(
  */
 void tcp_async::stop_acceptor(
     std::shared_ptr<asio::ip::tcp::acceptor> acceptor) {
-  if (_closed)
-    return;
 
   std::lock_guard<std::mutex> lck(_acceptor_con_m);
 
@@ -179,6 +138,8 @@ void tcp_async::handle_accept(std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
   /* If we got a connection, we store it */
   if (!ec) {
     new_connection->update_peer();
+    asio::socket_base::keep_alive option{true};
+    new_connection->socket().set_option(option);
     std::lock_guard<std::mutex> lck(_acceptor_con_m);
     _acceptor_available_con.insert(
         std::make_pair(acceptor.get(), new_connection));

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -138,8 +138,6 @@ void tcp_async::handle_accept(std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
   /* If we got a connection, we store it */
   if (!ec) {
     new_connection->update_peer();
-    asio::socket_base::keep_alive option{true};
-    new_connection->socket().set_option(option);
     std::lock_guard<std::mutex> lck(_acceptor_con_m);
     _acceptor_available_con.insert(
         std::make_pair(acceptor.get(), new_connection));

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -51,7 +51,7 @@ count = 0
 
 try:
   while 1:
-    newSocket, address = sock.accept(  )
+    newSocket, address = sock.accept()
     print ("Connected from", address)
     # loop serving the new client
     first = True
@@ -75,5 +75,4 @@ try:
     newSocket.close()
     print ("Disconnected from", address)
 finally:
-  sock.close(  )
-
+  sock.close()


### PR DESCRIPTION
## Description

Sometimes with bad connections or because of others explanations, we can see cbd/centengine unable to connect to another cbd/engine with many CLOSE_WAIT on the acceptor side. This patch fixes this.

REFS: MON-6505

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [X] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)
