### PR TITLE
Mon 6369 broker hangs alone 20.10

### DIFF
--- a/core/inc/com/centreon/broker/config/applier/init.hh
+++ b/core/inc/com/centreon/broker/config/applier/init.hh
@@ -19,12 +19,15 @@
 #ifndef CCB_CONFIG_APPLIER_INIT_HH_
 #define CCB_CONFIG_APPLIER_INIT_HH_
 
+#include <atomic>
 #include "com/centreon/broker/namespace.hh"
 
 CCB_BEGIN()
 
 namespace config {
 namespace applier {
+enum applier_state { not_started, initialized, finished };
+extern std::atomic<applier_state> state;
 void deinit();
 void init();
 }  // namespace applier

--- a/core/inc/com/centreon/broker/log_v2.hh
+++ b/core/inc/com/centreon/broker/log_v2.hh
@@ -46,7 +46,7 @@ class log_v2 {
 
  public:
   static log_v2& instance();
-  bool load(std::string const& file,
+  bool load(const char* file,
             std::string const& broker_name,
             std::string& err);
 

--- a/core/inc/com/centreon/broker/log_v2.hh
+++ b/core/inc/com/centreon/broker/log_v2.hh
@@ -46,9 +46,7 @@ class log_v2 {
 
  public:
   static log_v2& instance();
-  bool load(const char* file,
-            std::string const& broker_name,
-            std::string& err);
+  bool load(const char* file, std::string const& broker_name, std::string& err);
 
   static std::shared_ptr<spdlog::logger> core();
   static std::shared_ptr<spdlog::logger> config();

--- a/core/inc/com/centreon/broker/multiplexing/engine.hh
+++ b/core/inc/com/centreon/broker/multiplexing/engine.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2009-2012,2015 Centreon
+** Copyright 2009-2012,2015,2019-2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ class muxer;
  *  @class engine engine.hh "com/centreon/broker/multiplexing/engine.hh"
  *  @brief Multiplexing engine.
  *
- *  Core multiplexing engine. Send events to and receive events from
+ *  Core multiplexing engine. Sends events to and receives events from
  *  muxer objects.
  *
  *  This class has a unique instance. Before calling the instance() method,

--- a/core/inc/com/centreon/broker/multiplexing/engine.hh
+++ b/core/inc/com/centreon/broker/multiplexing/engine.hh
@@ -91,7 +91,7 @@ class engine {
   ~engine() noexcept = default;
   void clear();
   void publish(const std::shared_ptr<io::data>& d);
-  void publish(std::list<const std::shared_ptr<io::data>>& to_publish);
+  void publish(const std::list<std::shared_ptr<io::data>>& to_publish);
   void start();
   void stop();
   void hook(hooker& h, bool with_data = true);

--- a/core/inc/com/centreon/broker/multiplexing/engine.hh
+++ b/core/inc/com/centreon/broker/multiplexing/engine.hh
@@ -41,6 +41,13 @@ class muxer;
  *  Core multiplexing engine. Send events to and receive events from
  *  muxer objects.
  *
+ *  This class has a unique instance. Before calling the instance() method,
+ *  we have to call the static load() one. And to close this instance, we
+ *  have to call the static method unload().
+ *
+ *  The instance initialization/deinitialization are guarded by a mutex
+ *  _load_m. It is only used for that purpose.
+ *
  *  @see muxer
  */
 class engine {
@@ -62,6 +69,8 @@ class engine {
   std::vector<muxer*> _muxers;
   std::mutex _muxers_m;
 
+  static std::mutex _load_m;
+
   engine();
   std::string _cache_file_path() const;
   void _nop(std::shared_ptr<io::data> const& d);
@@ -73,21 +82,21 @@ class engine {
   void (engine::*_write_func)(std::shared_ptr<io::data> const&);
 
  public:
-  engine(engine const& other) = delete;
-  engine& operator=(engine const& other) = delete;
-  ~engine();
-  void clear();
-  void hook(hooker& h, bool with_data = true);
-  static engine& instance();
   static void load();
-  static std::mutex _load_m;
-  void publish(std::shared_ptr<io::data> const& d);
-  void publish(std::list<std::shared_ptr<io::data>> const& to_publish);
+  static void unload();
+  static engine& instance();
+
+  engine(engine const&) = delete;
+  engine& operator=(engine const&) = delete;
+  ~engine() noexcept = default;
+  void clear();
+  void publish(const std::shared_ptr<io::data>& d);
+  void publish(std::list<const std::shared_ptr<io::data>>& to_publish);
   void start();
   void stop();
-  void subscribe(muxer* subscriber);
+  void hook(hooker& h, bool with_data = true);
   void unhook(hooker& h);
-  static void unload();
+  void subscribe(muxer* subscriber);
   void unsubscribe(muxer* subscriber);
 };
 }  // namespace multiplexing

--- a/core/inc/com/centreon/broker/mysql_connection.hh
+++ b/core/inc/com/centreon/broker/mysql_connection.hh
@@ -41,6 +41,22 @@ using my_error = database::mysql_error;
  * "com/centreon/broker/mysql_connection.hh"
  *  @brief Class representing a thread connected to the mysql server
  *
+ *  mysql_connection classes are instanciated by the mysql_manager and then
+ *  shared with the mysql objects asking for them. The developer has not to
+ *  deal directly with mysql_connection. The are private objects of the mysql
+ *  object.
+ *
+ *  When a query is asked through the mysql object, the developer sets a
+ *  connection number (an index of the connection indexed from 0) or -1. With
+ *  -1, the mysql object chooses the connection that has the least tasks.
+ *  Then it sends the query to the good connection.
+ *
+ *  Queries in a connection are done asynchronously. We know when we ask for
+ *  them, we don't know when we will have them. If a query A is sent before
+ *  a query B, then A will be sent to the database before B.
+ *
+ *  A connection works with a list. Each query is pushed back on it. An internal
+ *  thread pops them one by one to send to the database.
  */
 class mysql_connection {
  public:
@@ -50,6 +66,64 @@ class mysql_connection {
     finished
   };
 
+ private:
+  std::unique_ptr<std::thread> _thread;
+  MYSQL* _conn;
+
+  // Mutex and condition working on _tasks_list.
+  std::mutex _list_mutex;
+  std::condition_variable _tasks_condition;
+  std::atomic<bool> _finished;
+  std::list<std::shared_ptr<database::mysql_task>> _tasks_list;
+  std::atomic_int _tasks_count;
+  bool _need_commit;
+
+  std::unordered_map<uint32_t, MYSQL_STMT*> _stmt;
+  std::unordered_map<uint32_t, std::string> _stmt_query;
+
+  // Mutex and condition working on result and error_msg.
+  std::mutex _result_mutex;
+  std::condition_variable _result_condition;
+
+  // Mutex to access the configuration
+  mutable std::mutex _cfg_mutex;
+  std::string _host;
+  std::string _user;
+  std::string _pwd;
+  std::string _name;
+  int _port;
+  connection_state _state;
+  uint32_t _qps;
+
+  /* mutex to protect the string access in _error */
+  mutable std::mutex _error_m;
+  database::mysql_error _error;
+  /**************************************************************************/
+  /*                    Methods executed by this thread                     */
+  /**************************************************************************/
+
+  bool _server_error(int code) const;
+  void _run();
+  std::string _get_stack();
+  void _query(database::mysql_task* t);
+  void _query_res(database::mysql_task* t);
+  void _query_int(database::mysql_task* t);
+  void _commit(database::mysql_task* t);
+  void _prepare(database::mysql_task* t);
+  void _statement(database::mysql_task* t);
+  void _statement_res(database::mysql_task* t);
+  template <typename T>
+  void _statement_int(database::mysql_task* t);
+  void _get_result_sync(database::mysql_task* task);
+  void _fetch_row_sync(database::mysql_task* task);
+  void _finish(database::mysql_task* task);
+  void _push(std::shared_ptr<database::mysql_task> const& q);
+  void _debug(MYSQL_BIND* bind, uint32_t size);
+
+  static void (mysql_connection::*const _task_processing_table[])(
+      database::mysql_task* task);
+
+ public:
   /**************************************************************************/
   /*                  Methods executed by the main thread                   */
   /**************************************************************************/
@@ -100,66 +174,6 @@ class mysql_connection {
     if (!_error.is_active())
       _error.set_message(fmt, args...);
   }
-
- private:
-  /**************************************************************************/
-  /*                    Methods executed by this thread                     */
-  /**************************************************************************/
-
-  bool _server_error(int code) const;
-  void _run();
-  std::string _get_stack();
-  void _query(database::mysql_task* t);
-  void _query_res(database::mysql_task* t);
-  void _query_int(database::mysql_task* t);
-  void _commit(database::mysql_task* t);
-  void _prepare(database::mysql_task* t);
-  void _statement(database::mysql_task* t);
-  void _statement_res(database::mysql_task* t);
-  template <typename T>
-  void _statement_int(database::mysql_task* t);
-  void _get_result_sync(database::mysql_task* task);
-  void _fetch_row_sync(database::mysql_task* task);
-  void _finish(database::mysql_task* task);
-  void _push(std::shared_ptr<database::mysql_task> const& q);
-  void _debug(MYSQL_BIND* bind, uint32_t size);
-
-  static void (mysql_connection::*const _task_processing_table[])(
-      database::mysql_task* task);
-
-  std::unique_ptr<std::thread> _thread;
-  MYSQL* _conn;
-
-  // Mutex and condition working on _tasks_list.
-  std::mutex _list_mutex;
-  std::condition_variable _tasks_condition;
-  std::atomic<bool> _finished;
-  std::list<std::shared_ptr<database::mysql_task>> _tasks_list;
-  std::atomic_int _tasks_count;
-  bool _need_commit;
-
-  std::unordered_map<uint32_t, MYSQL_STMT*> _stmt;
-
-  // FIXME DBR: to debug: Logs must be well implemented
-  std::unordered_map<uint32_t, std::string> _stmt_query;
-
-  // Mutex and condition working on result and error_msg.
-  std::mutex _result_mutex;
-  std::condition_variable _result_condition;
-
-  // Mutex to access the configuration
-  mutable std::mutex _cfg_mutex;
-  std::string _host;
-  std::string _user;
-  std::string _pwd;
-  std::string _name;
-  int _port;
-  connection_state _state;
-  uint32_t _qps;
-
-  /* mutex to protect the string access in _error */
-  mutable std::mutex _error_m;
-  database::mysql_error _error;
 };
 
 CCB_END()

--- a/core/inc/com/centreon/broker/mysql_connection.hh
+++ b/core/inc/com/centreon/broker/mysql_connection.hh
@@ -44,6 +44,12 @@ using my_error = database::mysql_error;
  */
 class mysql_connection {
  public:
+  enum connection_state {
+    not_started,
+    running,
+    finished
+  };
+
   /**************************************************************************/
   /*                  Methods executed by the main thread                   */
   /**************************************************************************/
@@ -148,7 +154,7 @@ class mysql_connection {
   std::string _pwd;
   std::string _name;
   int _port;
-  bool _started;
+  connection_state _state;
   uint32_t _qps;
 
   /* mutex to protect the string access in _error */

--- a/core/inc/com/centreon/broker/mysql_connection.hh
+++ b/core/inc/com/centreon/broker/mysql_connection.hh
@@ -60,11 +60,7 @@ using my_error = database::mysql_error;
  */
 class mysql_connection {
  public:
-  enum connection_state {
-    not_started,
-    running,
-    finished
-  };
+  enum connection_state { not_started, running, finished };
 
  private:
   std::unique_ptr<std::thread> _thread;

--- a/core/inc/com/centreon/broker/mysql_manager.hh
+++ b/core/inc/com/centreon/broker/mysql_manager.hh
@@ -53,7 +53,6 @@ class mysql_manager {
  private:
   mysql_manager();
   ~mysql_manager();
-  static mysql_manager _singleton;
   mutable std::mutex _cfg_mutex;
   std::vector<std::shared_ptr<mysql_connection>> _connection;
 

--- a/core/inc/com/centreon/broker/mysql_manager.hh
+++ b/core/inc/com/centreon/broker/mysql_manager.hh
@@ -33,35 +33,55 @@ CCB_BEGIN()
  * "com/centreon/broker/storage/mysql_manager.hh"
  *  @brief Class managing the mysql thread connections
  *
- *  Here is a mysql threads manager. It creates, destroyes, configures
- * mysql_connections.
+ *  Here is the mysql connection manager. It creates, destroyes, configures
+ * mysql_connections. It is used as a unique instance transparently through
+ * the mysql class.
+ *
+ * The developer creates a mysql object with a little configuration. Through
+ * this object, he can get connections to the database and then send queries
+ * always through the mysql object.
+ *
+ * So from the developer point of view, only the mysql object is seen.
+ *
+ * A mysql object contains a configuration with user/password, database host,
+ * a port, a number of queries per transaction. When it is constructed, it asks
+ * the manager to get the good number of connections following its
+ * configuration. The manager owns all the databases connections, if it already
+ * has connections matching the mysql object, they are given to it. If some
+ * miss, the manager creates them and keeps them in a vector _connection.
+ *
+ * The mysql object asks for its connections using the internal function
+ * get_connections(const database_config& db_cfg) that returns a vector
+ * containing the asked connections. Connections can be shared between several
+ * mysql objects.
+ *
+ * When a connection is no more used, it is the manager work to destroy it.
+ * This work of cleanup is done when a new mysql object is created, or when
+ * a mysql object is destroyed.
+ *
+ * The manager works on the connections statistics. It centralizes the number of
+ * tasks waiting on each connection.
+ *
  */
 class mysql_manager {
- public:
-  static mysql_manager& instance();
-  std::vector<std::shared_ptr<mysql_connection>> get_connections(
-      database_config const& db_cfg);
-  bool commit_if_needed();
-  bool is_in_error() const;
-  void clear_error();
-  database::mysql_error get_error();
-  void set_error(std::string const& message);
-  std::map<std::string, std::string> get_stats();
-  void update_connections();
-  void clear();
-
- private:
-  mysql_manager();
-  ~mysql_manager();
   mutable std::mutex _cfg_mutex;
   std::vector<std::shared_ptr<mysql_connection>> _connection;
-
-  int _current_thread;
 
   // last stats update timestamp
   time_t _stats_connections_timestamp;
   // Number of tasks per connection
   std::vector<int> _stats_counts;
+
+  mysql_manager();
+
+ public:
+  ~mysql_manager();
+  static mysql_manager& instance();
+  std::vector<std::shared_ptr<mysql_connection>> get_connections(
+      database_config const& db_cfg);
+  std::map<std::string, std::string> get_stats();
+  void update_connections();
+  void clear();
 };
 
 CCB_END()

--- a/core/inc/com/centreon/broker/processing/failover.hh
+++ b/core/inc/com/centreon/broker/processing/failover.hh
@@ -61,8 +61,7 @@ class failover : public endpoint {
   bool _stopped;
   mutable std::mutex _stopped_m;
   std::condition_variable _stopped_cv;
-
-  void _callback();
+  void _run();
 
  public:
   failover(std::shared_ptr<io::endpoint> endp,
@@ -75,7 +74,6 @@ class failover : public endpoint {
   time_t get_buffering_timeout() const throw();
   bool get_initialized() const throw();
   time_t get_retry_interval() const throw();
-  void run();
   void start() override;
   void exit() override;
   bool should_exit() const;

--- a/core/inc/com/centreon/broker/processing/failover.hh
+++ b/core/inc/com/centreon/broker/processing/failover.hh
@@ -81,7 +81,6 @@ class failover : public endpoint {
   void set_failover(std::shared_ptr<processing::failover> fo);
   void set_retry_interval(time_t retry_interval);
   void update() override;
-  //bool wait(unsigned long time = ULONG_MAX);
 
  protected:
   // From stat_visitable

--- a/core/src/broker_impl.cc
+++ b/core/src/broker_impl.cc
@@ -49,7 +49,7 @@ grpc::Status broker_impl::DebugConfReload(grpc::ServerContext* context,
                                           const GenericString* request,
                                           GenericResponse* response) {
   std::string err;
-  if (log_v2::instance().load(request->str_arg(), _broker_name, err)) {
+  if (log_v2::instance().load(request->str_arg().c_str(), _broker_name, err)) {
     response->set_ok(true);
     response->set_err_msg("");
   } else {

--- a/core/src/broker_impl.cc
+++ b/core/src/broker_impl.cc
@@ -112,14 +112,16 @@ grpc::Status broker_impl::GetModulesStats(grpc::ServerContext* context,
         }
       }
       if (!found)
-        return grpc::Status(grpc::INVALID_ARGUMENT, grpc::string("name not found"));
+        return grpc::Status(grpc::INVALID_ARGUMENT,
+                            grpc::string("name not found"));
 
       break;
 
     case GenericNameOrIndex::kIdx:
 
       if (request->idx() + 1 > value.size())
-        return grpc::Status(grpc::INVALID_ARGUMENT, grpc::string("idx too big"));
+        return grpc::Status(grpc::INVALID_ARGUMENT,
+                            grpc::string("idx too big"));
 
       val = value[request->idx()];
       response->set_str_arg(std::move(val.dump()));
@@ -167,13 +169,15 @@ grpc::Status broker_impl::GetEndpointStats(grpc::ServerContext* context,
         }
       }
       if (!found)
-        return grpc::Status(grpc::INVALID_ARGUMENT, grpc::string("name not found"));
+        return grpc::Status(grpc::INVALID_ARGUMENT,
+                            grpc::string("name not found"));
       break;
 
     case GenericNameOrIndex::kIdx:
 
       if ((request->idx() + 1) > value.size())
-        return grpc::Status(grpc::INVALID_ARGUMENT, grpc::string("idx too big"));
+        return grpc::Status(grpc::INVALID_ARGUMENT,
+                            grpc::string("idx too big"));
 
       val = value[request->idx()];
       response->set_str_arg(std::move(val.dump()));
@@ -190,7 +194,6 @@ grpc::Status broker_impl::GetGenericStats(
     grpc::ServerContext* context,
     const ::google::protobuf::Empty* request,
     GenericString* response) {
-
   json11::Json::object object;
   stats::get_generic_stats(object);
 
@@ -203,7 +206,6 @@ grpc::Status broker_impl::GetGenericStats(
 grpc::Status broker_impl::GetSqlStats(grpc::ServerContext* context,
                                       const ::google::protobuf::Empty* request,
                                       GenericString* response) {
-
   json11::Json::object object;
   stats::get_mysql_stats(object);
 

--- a/core/src/config/applier/endpoint.cc
+++ b/core/src/config/applier/endpoint.cc
@@ -111,9 +111,9 @@ endpoint::~endpoint() {
  */
 void endpoint::apply(std::list<config::endpoint> const& endpoints) {
   // Log messages.
-  logging::config(logging::medium) << "endpoint applier: loading configuration";
-  logging::debug(logging::high)
-      << "endpoint applier: " << endpoints.size() << " endpoints to apply";
+  log_v2::config()->info("endpoint applier: loading configuration");
+  log_v2::config()->debug("endpoint applier: {} endpoints to apply",
+                          endpoints.size());
 
   {
     std::vector<std::string> eps;

--- a/core/src/config/applier/endpoint.cc
+++ b/core/src/config/applier/endpoint.cc
@@ -47,11 +47,10 @@ using namespace com::centreon::broker::config::applier;
 // Class instance.
 static config::applier::endpoint* gl_endpoint = nullptr;
 
-/**************************************
- *                                     *
- *            Local Objects            *
- *                                     *
- **************************************/
+/**
+ * @brief Default constructor.
+ */
+endpoint::endpoint() : _discarding{false} {}
 
 /**
  *  Comparison classes.
@@ -160,6 +159,7 @@ void endpoint::apply(std::list<config::endpoint> const& endpoints) {
 
   // Create new endpoints.
   for (config::endpoint& ep : endp_to_create) {
+    assert(!_discarding);
     // Check that output is not a failover.
     if (ep.name.empty() ||
         (std::find_if(endp_to_create.begin(), endp_to_create.end(),
@@ -184,10 +184,7 @@ void endpoint::apply(std::list<config::endpoint> const& endpoints) {
       }
 
       // Run thread.
-      logging::debug(logging::medium) << "endpoint applier: endpoint "
-                                         "thread "
-                                      << endp.get() << " of '" << ep.name
-                                      << "' is registered and ready to run";
+      log_v2::config()->debug("endpoint applier: endpoint thread {} of '{}' is registered and ready to run", static_cast<void*>(endp.get()), ep.name);
       endp.release()->start();
     }
   }
@@ -197,6 +194,7 @@ void endpoint::apply(std::list<config::endpoint> const& endpoints) {
  *  Discard applied configuration.
  */
 void endpoint::discard() {
+  _discarding = true;
   log_v2::config()->debug("endpoint applier: destruction");
 
   // Stop multiplexing.
@@ -272,16 +270,6 @@ void endpoint::unload() {
   delete gl_endpoint;
   gl_endpoint = nullptr;
 }
-/**************************************
- *                                     *
- *           Private Methods           *
- *                                     *
- **************************************/
-
-/**
- *  Default constructor.
- */
-endpoint::endpoint() {}
 
 /**
  *  Create a muxer for a chain of failovers / endpoints. This method

--- a/core/src/config/applier/endpoint.cc
+++ b/core/src/config/applier/endpoint.cc
@@ -119,7 +119,8 @@ void endpoint::apply(std::list<config::endpoint> const& endpoints) {
     for (auto& ep : endpoints)
       eps.push_back(ep.name);
     log_v2::core()->debug("endpoint applier: {} endpoints to apply: {}",
-                          endpoints.size(), fmt::format("{}", fmt::join(eps, ", ")));
+                          endpoints.size(),
+                          fmt::format("{}", fmt::join(eps, ", ")));
   }
 
   // Copy endpoint configurations and apply eventual modifications.
@@ -184,7 +185,10 @@ void endpoint::apply(std::list<config::endpoint> const& endpoints) {
       }
 
       // Run thread.
-      log_v2::config()->debug("endpoint applier: endpoint thread {} of '{}' is registered and ready to run", static_cast<void*>(endp.get()), ep.name);
+      log_v2::config()->debug(
+          "endpoint applier: endpoint thread {} of '{}' is registered and "
+          "ready to run",
+          static_cast<void*>(endp.get()), ep.name);
       endp.release()->start();
     }
   }

--- a/core/src/config/applier/init.cc
+++ b/core/src/config/applier/init.cc
@@ -66,7 +66,6 @@ void config::applier::init() {
   io::protocols::load();
   config::applier::modules::load();
   file::load();
-  //extcmd::load();
   instance_broadcast::load();
   compression::load();
   bbdo::load();

--- a/core/src/config/applier/init.cc
+++ b/core/src/config/applier/init.cc
@@ -36,22 +36,18 @@
 
 using namespace com::centreon::broker;
 
-/**************************************
- *                                     *
- *           Global Functions          *
- *                                     *
- **************************************/
+std::atomic<config::applier::applier_state> config::applier::state{not_started};
 
 /**
  *  Unload necessary structures.
  */
 void config::applier::deinit() {
+  state = finished;
   config::applier::endpoint::unload();
   config::applier::logger::unload();
   config::applier::state::unload();
   bbdo::unload();
   compression::unload();
-  //extcmd::unload();
   file::unload();
   multiplexing::engine::instance().clear();
   config::applier::modules::unload();
@@ -77,4 +73,5 @@ void config::applier::init() {
   config::applier::logger::load();
   config::applier::endpoint::load();
   config::applier::state::load();
+  state = initialized;
 }

--- a/core/src/log_v2.cc
+++ b/core/src/log_v2.cc
@@ -24,6 +24,7 @@
 
 #include <fstream>
 #include <json11.hpp>
+#include <fmt/format.h>
 
 #include "com/centreon/broker/logging/logging.hh"
 
@@ -78,7 +79,7 @@ static auto json_validate = [](Json const& js) -> bool {
   return true;
 };
 
-bool log_v2::load(std::string const& file,
+bool log_v2::load(const char* file,
                   std::string const& broker_name,
                   std::string& err) {
   std::lock_guard<std::mutex> lock(_load_m);
@@ -106,7 +107,7 @@ bool log_v2::load(std::string const& file,
           sinks.push_back(
               std::make_shared<sinks::basic_file_sink_mt>(log_name));
         } catch (...) {
-          err = "log_v2 cannot log on '" + log_name + "'";
+          err = fmt::format("log_v2 cannot log on '{}'", log_name);
           return false;
         }
       }
@@ -150,11 +151,11 @@ bool log_v2::load(std::string const& file,
       return true;
     }
 
-    err = "bad format for config file '" + file + "'";
+    err = fmt::format("bad format for config file '{}'", file);
     return false;
   }
 
-  err = "file '" + file + "' does not exist";
+  err = fmt::format("file '{}' does not exist", file);
   return false;
 }
 

--- a/core/src/log_v2.cc
+++ b/core/src/log_v2.cc
@@ -22,9 +22,9 @@
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
+#include <fmt/format.h>
 #include <fstream>
 #include <json11.hpp>
-#include <fmt/format.h>
 
 #include "com/centreon/broker/logging/logging.hh"
 

--- a/core/src/main.cc
+++ b/core/src/main.cc
@@ -80,6 +80,10 @@ static void hup_handler(int signum) {
     // Parse configuration file.
     config::parser parsr;
     config::state conf{parsr.parse(gl_mainconfigfiles.front())};
+    std::string err;
+    if (!log_v2::instance().load("/etc/centreon-broker/log-config.json",
+          conf.broker_name(), err))
+      logging::error(logging::low) << err;
 
     try {
       // Apply resulting configuration.
@@ -152,7 +156,7 @@ static void term_handler(int signum, siginfo_t* info, void* data) {
  */
 int main(int argc, char* argv[]) {
   // Initialization.
-  int opt, option_index = 0, n_thread = 0; 
+  int opt, option_index = 0, n_thread = 0;
   config::applier::init();
   std::string broker_name = "unknown";
   uint16_t default_port{51000};
@@ -274,6 +278,10 @@ int main(int argc, char* argv[]) {
         // Parse configuration file.
         config::parser parsr;
         config::state conf{parsr.parse(gl_mainconfigfiles.front())};
+        std::string err;
+        if (!log_v2::instance().load("/etc/centreon-broker/log-config.json",
+              conf.broker_name(), err))
+          logging::error(logging::low) << err;
 
         // Verification modifications.
         if (check) {
@@ -298,11 +306,7 @@ int main(int argc, char* argv[]) {
 
         // Apply resulting configuration totally or partially.
         config::applier::state::instance().apply(conf, !check);
-        std::string err;
         broker_name = conf.broker_name();
-        if (!log_v2::instance().load("/etc/centreon-broker/log-config.json",
-                                     broker_name, err))
-          logging::error(logging::low) << err;
         gl_state = conf;
       }
 

--- a/core/src/main.cc
+++ b/core/src/main.cc
@@ -16,6 +16,7 @@
 ** For more information : contact@centreon.com
 */
 
+#include <getopt.h>
 #include <cerrno>
 #include <chrono>
 #include <clocale>
@@ -24,7 +25,6 @@
 #include <cstring>
 #include <exception>
 #include <thread>
-#include <getopt.h>
 
 #include "com/centreon/broker/brokerrpc.hh"
 #include "com/centreon/broker/config/applier/init.hh"
@@ -34,9 +34,9 @@
 #include "com/centreon/broker/config/parser.hh"
 #include "com/centreon/broker/config/state.hh"
 #include "com/centreon/broker/log_v2.hh"
-#include "com/centreon/broker/pool.hh"
 #include "com/centreon/broker/logging/logging.hh"
 #include "com/centreon/broker/misc/diagnostic.hh"
+#include "com/centreon/broker/pool.hh"
 
 using namespace com::centreon::broker;
 
@@ -50,15 +50,13 @@ using namespace com::centreon::broker;
 static std::vector<std::string> gl_mainconfigfiles;
 static config::state gl_state;
 
-static struct option long_options[] = {
-  {"pool_size",   required_argument, 0, 's'},
-  {"check",       no_argument,       0, 'c'},
-  {"debug",       no_argument,       0, 'd'},
-  {"diagnose",    no_argument,       0, 'D'},
-  {"version",     no_argument,       0, 'v'},
-  {"help",        no_argument,       0, 'h'},
-  {0, 0, 0, 0}
-};
+static struct option long_options[] = {{"pool_size", required_argument, 0, 's'},
+                                       {"check", no_argument, 0, 'c'},
+                                       {"debug", no_argument, 0, 'd'},
+                                       {"diagnose", no_argument, 0, 'D'},
+                                       {"version", no_argument, 0, 'v'},
+                                       {"help", no_argument, 0, 'h'},
+                                       {0, 0, 0, 0}};
 
 /**
  *  Function called when updating configuration (when program receives
@@ -82,7 +80,7 @@ static void hup_handler(int signum) {
     config::state conf{parsr.parse(gl_mainconfigfiles.front())};
     std::string err;
     if (!log_v2::instance().load("/etc/centreon-broker/log-config.json",
-          conf.broker_name(), err))
+                                 conf.broker_name(), err))
       logging::error(logging::low) << err;
 
     try {
@@ -172,8 +170,7 @@ int main(int argc, char* argv[]) {
     bool help(false);
     bool version(false);
 
-    opt = getopt_long (argc, argv, "p:cdDvh",
-                        long_options, &option_index);
+    opt = getopt_long(argc, argv, "p:cdDvh", long_options, &option_index);
     switch (opt) {
       case 'p':
         n_thread = atoi(optarg);
@@ -200,8 +197,6 @@ int main(int argc, char* argv[]) {
     if (optind < argc)
       while (optind < argc)
         gl_mainconfigfiles.push_back(argv[optind++]);
-      
-    
 
     // Apply default configuration.
     config::state default_state;
@@ -241,7 +236,8 @@ int main(int argc, char* argv[]) {
       diag.generate(gl_mainconfigfiles);
     } else if (help) {
       logging::info(logging::high)
-          << "USAGE: " << argv[0] << " [-t] [-c] [-d] [-D] [-h] [-v] [<configfile>]";
+          << "USAGE: " << argv[0]
+          << " [-t] [-c] [-d] [-D] [-h] [-v] [<configfile>]";
       logging::info(logging::high) << "  -t  Set x threads.";
       logging::info(logging::high) << "  -c  Check configuration file.";
       logging::info(logging::high) << "  -d  Enable debug mode.";
@@ -261,8 +257,9 @@ int main(int argc, char* argv[]) {
       retval = 0;
     } else if (gl_mainconfigfiles.empty()) {
       logging::error(logging::high)
-          << "USAGE: " << argv[0] << " [-c] [-d] [-D] [-h] [-v] [<configfile>]\n\n";
-        return 1;
+          << "USAGE: " << argv[0]
+          << " [-c] [-d] [-D] [-h] [-v] [<configfile>]\n\n";
+      return 1;
     } else {
       logging::info(logging::medium)
           << "Centreon Broker " << CENTREON_BROKER_VERSION;
@@ -280,7 +277,7 @@ int main(int argc, char* argv[]) {
         config::state conf{parsr.parse(gl_mainconfigfiles.front())};
         std::string err;
         if (!log_v2::instance().load("/etc/centreon-broker/log-config.json",
-              conf.broker_name(), err))
+                                     conf.broker_name(), err))
           logging::error(logging::low) << err;
 
         // Verification modifications.
@@ -293,9 +290,9 @@ int main(int argc, char* argv[]) {
           conf.loggers().push_back(default_state.loggers().front());
         }
 
-        if (n_thread > 0 && n_thread < 100) 
+        if (n_thread > 0 && n_thread < 100)
           pool::set_size(n_thread);
-        else 
+        else
           pool::set_size(conf.pool_size());
 
         // Add debug output if in debug mode.

--- a/core/src/multiplexing/engine.cc
+++ b/core/src/multiplexing/engine.cc
@@ -306,8 +306,8 @@ engine::engine()
  *  @return Path to the multiplexing engine cache file.
  */
 std::string engine::_cache_file_path() const {
-  std::string retval(fmt::format("{}.unprocessed",
-  config::applier::state::instance().cache_dir()));
+  std::string retval(fmt::format(
+      "{}.unprocessed", config::applier::state::instance().cache_dir()));
   return retval;
 }
 

--- a/core/src/multiplexing/engine.cc
+++ b/core/src/multiplexing/engine.cc
@@ -86,13 +86,13 @@ void engine::load() {
  *
  *  @param[in] e  Event to publish.
  */
-void engine::publish(std::shared_ptr<io::data> const& e) {
+void engine::publish(const std::shared_ptr<io::data>& e) {
   // Lock mutex.
   std::lock_guard<std::mutex> lock(_engine_m);
   _publish(e);
 }
 
-void engine::publish(std::list<std::shared_ptr<io::data>> const& to_publish) {
+void engine::publish(const std::list<std::shared_ptr<io::data>>& to_publish) {
   std::lock_guard<std::mutex> lock(_engine_m);
   for (auto& e : to_publish)
     _publish(e);

--- a/core/src/multiplexing/engine.cc
+++ b/core/src/multiplexing/engine.cc
@@ -20,6 +20,7 @@
 
 #include <unistd.h>
 
+#include <fmt/format.h>
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -35,26 +36,9 @@
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::multiplexing;
 
-/**************************************
- *                                     *
- *            Local Objects            *
- *                                     *
- **************************************/
-
 // Class instance.
 engine* engine::_instance(nullptr);
 std::mutex engine::_load_m;
-
-/**************************************
- *                                     *
- *           Public Methods            *
- *                                     *
- **************************************/
-
-/**
- *  Destructor.
- */
-engine::~engine() {}
 
 /**
  *  Clear events stored in the multiplexing engine.
@@ -322,8 +306,8 @@ engine::engine()
  *  @return Path to the multiplexing engine cache file.
  */
 std::string engine::_cache_file_path() const {
-  std::string retval(config::applier::state::instance().cache_dir());
-  retval.append(".unprocessed");
+  std::string retval(fmt::format("{}.unprocessed",
+  config::applier::state::instance().cache_dir()));
   return retval;
 }
 

--- a/core/src/mysql_connection.cc
+++ b/core/src/mysql_connection.cc
@@ -590,6 +590,10 @@ mysql_connection::mysql_connection(database_config const& db_cfg)
     _result_condition.wait(locker);
 }
 
+/**
+ * @brief Destructor. When called, the finish task is post on the stack. So
+ * the end will occur only when all the queries will be played.
+ */
 mysql_connection::~mysql_connection() {
   log_v2::sql()->info("mysql_connection: finished");
   finish();

--- a/core/src/mysql_connection.cc
+++ b/core/src/mysql_connection.cc
@@ -20,11 +20,11 @@
 #include <cstring>
 #include <sstream>
 
+#include "com/centreon/broker/config/applier/init.hh"
 #include "com/centreon/broker/exceptions/msg.hh"
 #include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/logging/logging.hh"
 #include "com/centreon/broker/mysql_manager.hh"
-#include "com/centreon/broker/config/applier/init.hh"
 
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::database;
@@ -525,9 +525,10 @@ void mysql_connection::_run() {
            !mysql_real_connect(_conn, _host.c_str(), _user.c_str(),
                                _pwd.c_str(), _name.c_str(), _port, nullptr,
                                CLIENT_FOUND_ROWS)) {
-      set_error_message(fmt::format("mysql_connection: The mysql/mariadb database seems not started. "
-             "Waiting before attempt to connect again: {}",
-           ::mysql_error(_conn)));
+      set_error_message(fmt::format(
+          "mysql_connection: The mysql/mariadb database seems not started. "
+          "Waiting before attempt to connect again: {}",
+          ::mysql_error(_conn)));
       _state = finished;
       _result_condition.notify_all();
       return;
@@ -538,8 +539,7 @@ void mysql_connection::_run() {
     _state = finished;
     locker.unlock();
     _result_condition.notify_all();
-  }
-  else {
+  } else {
     mysql_set_character_set(_conn, "utf8mb4");
 
     if (_qps > 1)
@@ -603,7 +603,8 @@ mysql_connection::mysql_connection(database_config const& db_cfg)
   _result_condition.wait(locker, [this] { return _state != not_started; });
   if (_state == finished) {
     _thread->join();
-    throw exceptions::msg() << "mysql_connection: error while starting connection";
+    throw exceptions::msg()
+        << "mysql_connection: error while starting connection";
   }
   log_v2::sql()->info("mysql_connection: connection started");
 }

--- a/core/src/mysql_manager.cc
+++ b/core/src/mysql_manager.cc
@@ -26,9 +26,8 @@
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::database;
 
-mysql_manager mysql_manager::_singleton;
-
 mysql_manager& mysql_manager::instance() {
+  static mysql_manager _singleton;
   return _singleton;
 }
 
@@ -62,6 +61,7 @@ mysql_manager::~mysql_manager() {
 
 std::vector<std::shared_ptr<mysql_connection>> mysql_manager::get_connections(
     database_config const& db_cfg) {
+  log_v2::sql()->trace("mysql_manager::get_connections");
   std::vector<std::shared_ptr<mysql_connection>> retval;
   uint32_t connection_count(db_cfg.get_connections_count());
 

--- a/core/src/mysql_manager.cc
+++ b/core/src/mysql_manager.cc
@@ -39,8 +39,7 @@ mysql_manager& mysql_manager::instance() {
 /**
  *  The default constructor
  */
-mysql_manager::mysql_manager()
-    : _stats_connections_timestamp(time(nullptr)) {
+mysql_manager::mysql_manager() : _stats_connections_timestamp(time(nullptr)) {
   log_v2::sql()->trace("mysql_manager instanciation");
 }
 

--- a/core/src/processing/failover.cc
+++ b/core/src/processing/failover.cc
@@ -59,7 +59,7 @@ failover::failover(std::shared_ptr<io::endpoint> endp,
       _subscriber(sbscrbr),
       _update(false) {
   log_v2::core()->trace("failover '{}' construction.", _name);
-      }
+}
 
 /**
  *  Destructor.
@@ -159,7 +159,8 @@ void failover::_run() {
       {
         std::shared_ptr<io::stream> s(_endpoint->open());
         if (!s)
-          throw exceptions::msg() << "failover: '" << _name << "' cannot connect endpoint.";
+          throw exceptions::msg()
+              << "failover: '" << _name << "' cannot connect endpoint.";
         {
           std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
           _stream = s;
@@ -250,19 +251,23 @@ void failover::_run() {
         d.reset();
         bool timed_out_stream(true);
         if (stream_can_read) {
-          log_v2::processing()->debug("failover: reading event from endpoint '{}'", _name);
+          log_v2::processing()->debug(
+              "failover: reading event from endpoint '{}'", _name);
           _update_status("reading event from stream");
           try {
             std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
             timed_out_stream = !_stream->read(d, 0);
           } catch (exceptions::shutdown const& e) {
             log_v2::processing()->debug(
-                "failover: stream of endpoint '{}' shutdown while reading: {}", _name, e.what());
+                "failover: stream of endpoint '{}' shutdown while reading: {}",
+                _name, e.what());
             stream_can_read = false;
           }
           if (d) {
             log_v2::processing()->debug(
-                "failover: writing event of endpoint '{}' to multiplexing engine", _name);
+                "failover: writing event of endpoint '{}' to multiplexing "
+                "engine",
+                _name);
             _update_status("writing event to multiplexing engine");
             _subscriber->get_muxer().write(d);
             tick();
@@ -276,8 +281,10 @@ void failover::_run() {
         d.reset();
         bool timed_out_muxer(true);
         if (muxer_can_read) {
-          log_v2::processing()->debug("failover: reading event from "
-                                          "multiplexing engine for endpoint '{}'", _name);
+          log_v2::processing()->debug(
+              "failover: reading event from "
+              "multiplexing engine for endpoint '{}'",
+              _name);
           _update_status("reading event from multiplexing engine");
           try {
             timed_out_muxer = !_subscriber->get_muxer().read(d, 0);
@@ -411,8 +418,8 @@ void failover::_run() {
   }
 
   // Exit log.
-  log_v2::processing()->debug(
-      "failover: thread of endpoint '{}' is exiting", _name);
+  log_v2::processing()->debug("failover: thread of endpoint '{}' is exiting",
+                              _name);
 
   std::unique_lock<std::mutex> lock_stop(_stopped_m);
   _stopped = true;

--- a/core/src/processing/failover.cc
+++ b/core/src/processing/failover.cc
@@ -49,7 +49,7 @@ failover::failover(std::shared_ptr<io::endpoint> endp,
     : endpoint(name),
       _should_exit(false),
       _started(false),
-      _stopped(false),
+      _stopped{false},
       _buffering_timeout(0),
       _endpoint(endp),
       _failover_launched(false),
@@ -57,7 +57,9 @@ failover::failover(std::shared_ptr<io::endpoint> endp,
       _next_timeout(0),
       _retry_interval(30),
       _subscriber(sbscrbr),
-      _update(false) {}
+      _update(false) {
+  log_v2::core()->trace("failover '{}' construction.", _name);
+      }
 
 /**
  *  Destructor.
@@ -79,6 +81,7 @@ void failover::add_secondary_endpoint(std::shared_ptr<io::endpoint> endp) {
  *  Exit failover thread.
  */
 void failover::exit() {
+  log_v2::core()->trace("failover '{}' exit.", _name);
   std::unique_lock<std::mutex> lock(_stopped_m);
   if (_started) {
     if (!_should_exit) {
@@ -90,6 +93,7 @@ void failover::exit() {
     }
   }
   _subscriber->get_muxer().wake();
+  log_v2::core()->trace("failover '{}' exited.", _name);
 }
 
 /**
@@ -122,7 +126,11 @@ time_t failover::get_retry_interval() const throw() {
 /**
  *  Thread core function.
  */
-void failover::run() {
+void failover::_run() {
+  std::unique_lock<std::mutex> lock_start(_started_m);
+  _started = true;
+  _started_cv.notify_all();
+  lock_start.unlock();
   // Initial log.
   log_v2::processing()->debug("failover: thread of endpoint '{}' is starting",
                               _name);
@@ -133,6 +141,9 @@ void failover::run() {
         << "failover: thread of endpoint '" << _name << "' has no endpoint"
         << " object, this is likely a software bug that should be reported"
         << " to Centreon Broker developers";
+    std::unique_lock<std::mutex> lock_stop(_stopped_m);
+    _stopped = true;
+    _stopped_cv.notify_all();
     return;
   }
 
@@ -148,7 +159,7 @@ void failover::run() {
       {
         std::shared_ptr<io::stream> s(_endpoint->open());
         if (!s)
-          throw exceptions::msg() << "failover: cannot connect endpoint.";
+          throw exceptions::msg() << "failover: '" << _name << "' cannot connect endpoint.";
         {
           std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
           _stream = s;
@@ -170,7 +181,7 @@ void failover::run() {
 
         // Wait loop.
         // FIXME SGA: condvar should be more elegant...
-        for (ssize_t i = 0; !should_exit() && i < (_buffering_timeout * 10);
+        for (ssize_t i = 0; !should_exit() && i < _buffering_timeout * 10;
              i++) {
           std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
@@ -202,8 +213,8 @@ void failover::run() {
 
       // Shutdown failover.
       if (_failover_launched) {
-        logging::debug(logging::medium)
-            << "failover: shutting down failover of endpoint '" << _name << "'";
+        log_v2::processing()->debug(
+            "failover: shutting down failover of endpoint '{}'", _name);
         _update_status("shutting down failover");
         _failover->exit();
         _failover_launched = false;
@@ -211,8 +222,8 @@ void failover::run() {
       }
 
       // Event processing loop.
-      logging::debug(logging::medium)
-          << "failover: launching event loop of endpoint '" << _name << "'";
+      log_v2::processing()->debug(
+          "failover: launching event loop of endpoint '{}'", _name);
       _subscriber->get_muxer().nack_events();
       bool stream_can_read(true);
       bool muxer_can_read(true);
@@ -239,22 +250,19 @@ void failover::run() {
         d.reset();
         bool timed_out_stream(true);
         if (stream_can_read) {
-          logging::debug(logging::low)
-              << "failover: reading event from endpoint '" << _name << "'";
+          log_v2::processing()->debug("failover: reading event from endpoint '{}'", _name);
           _update_status("reading event from stream");
           try {
             std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
             timed_out_stream = !_stream->read(d, 0);
           } catch (exceptions::shutdown const& e) {
-            logging::debug(logging::medium)
-                << "failover: stream of endpoint '" << _name
-                << "' shutdown while reading: " << e.what();
+            log_v2::processing()->debug(
+                "failover: stream of endpoint '{}' shutdown while reading: {}", _name, e.what());
             stream_can_read = false;
           }
           if (d) {
-            logging::debug(logging::low)
-                << "failover: writing event of endpoint '" << _name
-                << "' to multiplexing engine";
+            log_v2::processing()->debug(
+                "failover: writing event of endpoint '{}' to multiplexing engine", _name);
             _update_status("writing event to multiplexing engine");
             _subscriber->get_muxer().write(d);
             tick();
@@ -268,9 +276,8 @@ void failover::run() {
         d.reset();
         bool timed_out_muxer(true);
         if (muxer_can_read) {
-          logging::debug(logging::low) << "failover: reading event from "
-                                          "multiplexing engine for endpoint '"
-                                       << _name << "'";
+          log_v2::processing()->debug("failover: reading event from "
+                                          "multiplexing engine for endpoint '{}'", _name);
           _update_status("reading event from multiplexing engine");
           try {
             timed_out_muxer = !_subscriber->get_muxer().read(d, 0);
@@ -343,15 +350,17 @@ void failover::run() {
     }
     // Some real error occured.
     catch (std::exception const& e) {
-      log_v2::core()->error(e.what());
+      log_v2::core()->error("failover: global error: {}", e.what());
       logging::error(logging::high) << e.what();
       {
         std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
         _stream.reset();
         set_state("connecting");
       }
-      _launch_failover();
-      _initialized = true;
+      if (!should_exit()) {
+        _launch_failover();
+        _initialized = true;
+      }
     } catch (...) {
       logging::error(logging::high)
           << "failover: endpoint '" << _name
@@ -363,8 +372,10 @@ void failover::run() {
         _stream.reset();
         set_state("connecting");
       }
-      _launch_failover();
-      _initialized = true;
+      if (!should_exit()) {
+        _launch_failover();
+        _initialized = true;
+      }
     }
 
     // Clear stream.
@@ -394,15 +405,18 @@ void failover::run() {
 
   // Exit failover thread if necessary.
   if (_failover) {
-    logging::info(logging::medium)
-        << "failover: requesting termination of failover of endpoint '" << _name
-        << "'";
+    log_v2::processing()->info(
+        "failover: requesting termination of failover of endpoint '{}'", _name);
     _failover->exit();
   }
 
   // Exit log.
-  logging::debug(logging::high)
-      << "failover: thread of endpoint '" << _name << "' is exiting";
+  log_v2::processing()->debug(
+      "failover: thread of endpoint '{}' is exiting", _name);
+
+  std::unique_lock<std::mutex> lock_stop(_stopped_m);
+  _stopped = true;
+  _stopped_cv.notify_all();
 }
 
 /**
@@ -508,12 +522,6 @@ void failover::_forward_statistic(json11::Json::object& tree) {
   tree["failover"] = subtree;
 }
 
-/**************************************
- *                                     *
- *           Private Methods           *
- *                                     *
- **************************************/
-
 /**
  *  Launch failover of this endpoint.
  */
@@ -546,26 +554,15 @@ uint32_t failover::_get_queued_events() const {
  *  Start the internal thread.
  */
 void failover::start() {
+  log_v2::core()->trace("start failover '{}'.", _name);
   std::unique_lock<std::mutex> lock(_started_m);
   _stopped = false;
   if (!_started) {
     _should_exit = false;
-    _thread = std::thread(&failover::_callback, this);
+    _thread = std::thread(&failover::_run, this);
     _started_cv.wait(lock, [this] { return _started; });
   }
-}
-
-void failover::_callback() {
-  std::unique_lock<std::mutex> lock_start(_started_m);
-  _started = true;
-  _started_cv.notify_all();
-  lock_start.unlock();
-
-  run();
-
-  std::unique_lock<std::mutex> lock_stop(_stopped_m);
-  _stopped = true;
-  _stopped_cv.notify_all();
+  log_v2::core()->trace("failover '{}' started.", _name);
 }
 
 /**

--- a/core/test/config/parser.cc
+++ b/core/test/config/parser.cc
@@ -41,8 +41,7 @@ TEST(parser, endpoint) {
   // Open file.
   FILE* file_stream(fopen(config_file.c_str(), "w"));
   if (!file_stream)
-    throw exceptions::msg()
-          << "could not open '" << config_file.c_str() << "'";
+    throw exceptions::msg() << "could not open '" << config_file.c_str() << "'";
 
   // Data.
   std::string data{
@@ -99,7 +98,7 @@ TEST(parser, endpoint) {
   // Write data.
   if (fwrite(data.c_str(), data.size(), 1, file_stream) != 1)
     throw exceptions::msg()
-          << "could not write content of '" << config_file.c_str() << "'";
+        << "could not write content of '" << config_file.c_str() << "'";
 
   // Close file.
   fclose(file_stream);

--- a/core/test/config/parser.cc
+++ b/core/test/config/parser.cc
@@ -41,12 +41,11 @@ TEST(parser, endpoint) {
   // Open file.
   FILE* file_stream(fopen(config_file.c_str(), "w"));
   if (!file_stream)
-    throw(exceptions::msg()
-          << "could not open '" << config_file.c_str() << "'");
+    throw exceptions::msg()
+          << "could not open '" << config_file.c_str() << "'";
 
   // Data.
-  std::string data;
-  data =
+  std::string data{
       "\n{"
       "  \"centreonBroker\": {\n"
       "    \"input\": {\n"
@@ -95,12 +94,12 @@ TEST(parser, endpoint) {
       "      }\n"
       "    ]\n"
       "  }\n"
-      "}\n";
+      "}\n"};
 
   // Write data.
   if (fwrite(data.c_str(), data.size(), 1, file_stream) != 1)
-    throw(exceptions::msg()
-          << "could not write content of '" << config_file.c_str() << "'");
+    throw exceptions::msg()
+          << "could not write content of '" << config_file.c_str() << "'";
 
   // Close file.
   fclose(file_stream);

--- a/doc/en/release_notes/20.10.rst
+++ b/doc/en/release_notes/20.10.rst
@@ -6,10 +6,15 @@ Centreon Broker 20.10.4
 Bugs
 ****
 
-log file configuration
+Log file configuration
 ======================
 log file configuration is applied even if the configuration contains errors.
 Now '.' is allowed in names.
+
+Broker termination
+==================
+When broker is badly configured and the user wants to stop it, it may hang and
+never stop. This new version fixes this issue.
 
 =======================
 Centreon Broker 20.10.3

--- a/lua/src/broker_utils.cc
+++ b/lua/src/broker_utils.cc
@@ -127,7 +127,7 @@ static void escape_str(const char* content, std::ostringstream& oss) {
 }
 
 static void broker_json_encode_broker_event(std::shared_ptr<io::data> e,
-                                     std::ostringstream& oss) {
+                                            std::ostringstream& oss) {
   io::event_info const* info = io::events::instance().get_event_info(e->type());
   if (info) {
     oss << fmt::format("{{ \"_type\": {}, \"category\": {}, \"element\": {}",

--- a/lua/src/stream.cc
+++ b/lua/src/stream.cc
@@ -161,9 +161,7 @@ stream::stream(std::string const& lua_script,
     delete lb;
   });
 
-  init_cv.wait(lock, [&configured] {
-      return configured;
-  });
+  init_cv.wait(lock, [&configured] { return configured; });
   if (fail) {
     _thread.join();
     throw exceptions::msg() << fail_msg;

--- a/lua/src/stream.cc
+++ b/lua/src/stream.cc
@@ -1,5 +1,5 @@
 /*
-** Copyright 2017 Centreon
+** Copyright 2017-2020 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -161,7 +161,9 @@ stream::stream(std::string const& lua_script,
     delete lb;
   });
 
-  init_cv.wait(lock, [&configured] { return configured; });
+  init_cv.wait(lock, [&configured] {
+      return configured;
+  });
   if (fail) {
     _thread.join();
     throw exceptions::msg() << fail_msg;

--- a/sql/src/connector.cc
+++ b/sql/src/connector.cc
@@ -16,6 +16,7 @@
 ** For more information : contact@centreon.com
 */
 
+#include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/sql/connector.hh"
 
 #include "com/centreon/broker/sql/stream.hh"
@@ -63,6 +64,7 @@ void connector::connect_to(database_config const& dbcfg,
  *  @return SQL connection object.
  */
 std::shared_ptr<io::stream> connector::open() {
+  log_v2::sql()->trace("sql open connector...");
   return std::shared_ptr<io::stream>(
       std::make_shared<stream>(_dbcfg, _cleanup_check_interval, _loop_timeout,
                                _instance_timeout, _with_state_events));

--- a/sql/src/connector.cc
+++ b/sql/src/connector.cc
@@ -16,8 +16,8 @@
 ** For more information : contact@centreon.com
 */
 
-#include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/sql/connector.hh"
+#include "com/centreon/broker/log_v2.hh"
 
 #include "com/centreon/broker/sql/stream.hh"
 

--- a/sql/src/stream.cc
+++ b/sql/src/stream.cc
@@ -461,7 +461,7 @@ stream::~stream() {
   // Stop cleanup thread.
   //_cleanup_thread.exit();
   log_v2::sql()->debug("sql: stream destruction");
-  storage::conflict_manager::unload();
+  storage::conflict_manager::instance().unload(storage::conflict_manager::sql);
 }
 
 /**

--- a/sql/src/stream.cc
+++ b/sql/src/stream.cc
@@ -451,9 +451,10 @@ stream::stream(database_config const& dbcfg,
   //  // Run cleanup thread.
   //  _cleanup_thread.start();
   log_v2::sql()->debug("sql stream instanciation");
-  if (!storage::conflict_manager::init_sql(dbcfg, loop_timeout, instance_timeout))
+  if (!storage::conflict_manager::init_sql(dbcfg, loop_timeout,
+                                           instance_timeout))
     throw broker::exceptions::msg()
-      << "SQL: Unable to initialize the sql connection to the database";
+        << "SQL: Unable to initialize the sql connection to the database";
 }
 
 /**

--- a/sql/src/stream.cc
+++ b/sql/src/stream.cc
@@ -451,7 +451,9 @@ stream::stream(database_config const& dbcfg,
   //  // Run cleanup thread.
   //  _cleanup_thread.start();
   log_v2::sql()->debug("sql stream instanciation");
-  storage::conflict_manager::init_sql(dbcfg, loop_timeout, instance_timeout);
+  if (!storage::conflict_manager::init_sql(dbcfg, loop_timeout, instance_timeout))
+    throw broker::exceptions::msg()
+      << "SQL: Unable to initialize the sql connection to the database";
 }
 
 /**

--- a/storage/inc/com/centreon/broker/storage/conflict_manager.hh
+++ b/storage/inc/com/centreon/broker/storage/conflict_manager.hh
@@ -319,7 +319,7 @@ class conflict_manager {
   void __exit();
 
  public:
-  static void init_sql(database_config const& dbcfg,
+  static bool init_sql(database_config const& dbcfg,
                        uint32_t loop_timeout,
                        uint32_t instance_timeout);
   static bool init_storage(bool store_in_db,

--- a/storage/inc/com/centreon/broker/storage/conflict_manager.hh
+++ b/storage/inc/com/centreon/broker/storage/conflict_manager.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2019-2020 Centreon
+** Copyright 2019-2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -66,6 +66,16 @@ namespace storage {
  * Metrics, customvariables are sent in bulk to avoid locks on the database,
  * so we keep some containers here to build those big queries.
  *
+ * The conflict manager works with two streams: sql and storage.
+ *
+ * To initialize it, two functions are used:
+ * * init_sql(): initialization of the sql part.
+ * * init_storage(): initialization of the storage part. This one needs the
+ *   sql part to be initialized before. If it is not already initialized, this
+ *   function waits for it (with a timeout).
+ *
+ * Once the object is initialized, we have the classical static internal method
+ * `instance()`.
  */
 class conflict_manager {
   /* Forward declarations */

--- a/storage/inc/com/centreon/broker/storage/conflict_manager.hh
+++ b/storage/inc/com/centreon/broker/storage/conflict_manager.hh
@@ -70,6 +70,7 @@ namespace storage {
 class conflict_manager {
   /* Forward declarations */
  public:
+  enum instance_state { not_started, running, finished };
   enum stream_type { sql, storage };
 
  private:
@@ -128,6 +129,7 @@ class conflict_manager {
   static void (conflict_manager::*const _neb_processing_table[])(
       std::tuple<std::shared_ptr<io::data>, uint32_t, bool*>&);
   static conflict_manager* _singleton;
+  static instance_state _state;
   static std::mutex _init_m;
   static std::condition_variable _init_cv;
 

--- a/storage/inc/com/centreon/broker/storage/conflict_manager.hh
+++ b/storage/inc/com/centreon/broker/storage/conflict_manager.hh
@@ -325,7 +325,7 @@ class conflict_manager {
                            uint32_t interval_length,
                            uint32_t max_pending_queries);
   static conflict_manager& instance();
-  static void unload();
+  int32_t unload(stream_type type);
   json11::Json::object get_statistics();
 
   int32_t send_event(stream_type c, std::shared_ptr<io::data> const& e);

--- a/storage/inc/com/centreon/broker/storage/rebuilder.hh
+++ b/storage/inc/com/centreon/broker/storage/rebuilder.hh
@@ -85,7 +85,7 @@ class rebuilder {
                        uint32_t length);
   void _send_rebuild_event(bool end, uint32_t id, bool is_index);
   void _set_index_rebuild(mysql& db, uint32_t index_id, short state);
-  void _run();
+  void _run(asio::error_code ec);
 
 };
 }  // namespace storage

--- a/storage/inc/com/centreon/broker/storage/stream.hh
+++ b/storage/inc/com/centreon/broker/storage/stream.hh
@@ -71,7 +71,7 @@ class stream : public io::stream {
   };
 
   int32_t _pending_events;
-  //rebuilder _rebuilder;
+  rebuilder _rebuilder;
   std::string _status;
   mutable std::mutex _statusm;
 

--- a/storage/inc/com/centreon/broker/storage/stream.hh
+++ b/storage/inc/com/centreon/broker/storage/stream.hh
@@ -71,7 +71,7 @@ class stream : public io::stream {
   };
 
   int32_t _pending_events;
-  rebuilder _rebuilder;
+  //rebuilder _rebuilder;
   std::string _status;
   mutable std::mutex _statusm;
 

--- a/storage/src/conflict_manager.cc
+++ b/storage/src/conflict_manager.cc
@@ -629,9 +629,11 @@ int32_t conflict_manager::send_event(conflict_manager::stream_type c,
 
 /**
  *  This method is called from the stream and returns how many events should
- *  be released. By the way, it removed those objects from the queue.
+ *  be released. By the way, it removes those objects from the queue.
  *
- * @param c
+ * @param c a stream_type (we have two kinds of data arriving in the
+ * conflict_manager, those from the sql connector and those from the storage
+ * connector, so this stream_type is an enum containing those types).
  *
  * @return the number of events to ack.
  */
@@ -711,6 +713,12 @@ void conflict_manager::__exit() {
     _thread.join();
 }
 
+/**
+ * @brief Returns statistics about the conflict_manager. Those statistics
+ * are stored directly in a json tree.
+ *
+ * @return A json11::Json::object with the statistics.
+ */
 json11::Json::object conflict_manager::get_statistics() {
   json11::Json::object retval;
   retval["max pending events"] = static_cast<int32_t>(_max_pending_queries);

--- a/storage/src/conflict_manager.cc
+++ b/storage/src/conflict_manager.cc
@@ -126,7 +126,7 @@ bool conflict_manager::init_storage(bool store_in_db,
 
   for (count = 0; count < 10; count++) {
     /* Let's wait for 10s for the conflict_manager to be initialized */
-    if (_init_cv.wait_for(lk, std::chrono::seconds(10),
+    if (_init_cv.wait_for(lk, std::chrono::seconds(1),
                           [&] { return _singleton != nullptr || _state == finished; })) {
       if (_state == finished)
         return false;
@@ -148,6 +148,8 @@ bool conflict_manager::init_storage(bool store_in_db,
         "seconds",
         count);
   }
+  log_v2::sql()->error("conflict_manager: not initialized after 10s. Probably "
+      "an issue in the sql output configuration.");
   return false;
 }
 

--- a/storage/src/conflict_manager.cc
+++ b/storage/src/conflict_manager.cc
@@ -25,7 +25,6 @@
 #include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/logging/logging.hh"
 #include "com/centreon/broker/multiplexing/publisher.hh"
-#include "com/centreon/broker/mysql_manager.hh"
 #include "com/centreon/broker/neb/events.hh"
 #include "com/centreon/broker/storage/index_mapping.hh"
 #include "com/centreon/broker/storage/perfdata.hh"

--- a/storage/src/conflict_manager.cc
+++ b/storage/src/conflict_manager.cc
@@ -34,7 +34,8 @@ using namespace com::centreon::broker::database;
 using namespace com::centreon::broker::storage;
 
 conflict_manager* conflict_manager::_singleton = nullptr;
-conflict_manager::instance_state conflict_manager::_state{conflict_manager::not_started};
+conflict_manager::instance_state conflict_manager::_state{
+    conflict_manager::not_started};
 std::mutex conflict_manager::_init_m;
 std::condition_variable conflict_manager::_init_cv;
 
@@ -126,8 +127,9 @@ bool conflict_manager::init_storage(bool store_in_db,
 
   for (count = 0; count < 10; count++) {
     /* Let's wait for 10s for the conflict_manager to be initialized */
-    if (_init_cv.wait_for(lk, std::chrono::seconds(1),
-                          [&] { return _singleton != nullptr || _state == finished; })) {
+    if (_init_cv.wait_for(lk, std::chrono::seconds(1), [&] {
+          return _singleton != nullptr || _state == finished;
+        })) {
       if (_state == finished)
         return false;
       std::lock_guard<std::mutex> lk(_singleton->_loop_m);
@@ -148,7 +150,8 @@ bool conflict_manager::init_storage(bool store_in_db,
         "seconds",
         count);
   }
-  log_v2::sql()->error("conflict_manager: not initialized after 10s. Probably "
+  log_v2::sql()->error(
+      "conflict_manager: not initialized after 10s. Probably "
       "an issue in the sql output configuration.");
   return false;
 }
@@ -742,8 +745,7 @@ int32_t conflict_manager::unload(stream_type type) {
   if (!_singleton) {
     log_v2::sql()->info("conflict_manager: already unloaded.");
     return 0;
-  }
-  else {
+  } else {
     uint32_t count = --_singleton->_ref_count;
     int retval;
     if (count == 0) {

--- a/storage/src/rebuilder.cc
+++ b/storage/src/rebuilder.cc
@@ -1,5 +1,5 @@
 /*
-** Copyright 2012-2015,2017,2020 Centreon
+** Copyright 2012-2015,2017,2020-2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -69,24 +69,6 @@ rebuilder::rebuilder(database_config const& db_cfg,
 rebuilder::~rebuilder() {
   _should_exit = true;
   asio::post(_timer.get_executor(), [this]{ _timer.cancel(); });
-}
-
-/**
- *  Get the rebuild check interval.
- *
- *  @return Rebuild check interval in seconds.
- */
-uint32_t rebuilder::get_rebuild_check_interval() const noexcept {
-  return _rebuild_check_interval;
-}
-
-/**
- *  Get the RRD length in seconds.
- *
- *  @return RRD length in seconds.
- */
-uint32_t rebuilder::get_rrd_length() const noexcept {
-  return _rrd_len;
 }
 
 /**

--- a/storage/src/stream.cc
+++ b/storage/src/stream.cc
@@ -77,8 +77,8 @@ stream::stream(database_config const& dbcfg,
 
   if (!conflict_manager::init_storage(store_in_db, rrd_len, interval_length,
                                       dbcfg.get_queries_per_transaction()))
-    throw broker::exceptions::shutdown()
-        << "Unable to initialize the storage connection to the database";
+    throw broker::exceptions::msg()
+        << "storage: Unable to initialize the storage connection to the database";
 }
 
 /**

--- a/storage/src/stream.cc
+++ b/storage/src/stream.cc
@@ -77,8 +77,8 @@ stream::stream(database_config const& dbcfg,
 
   if (!conflict_manager::init_storage(store_in_db, rrd_len, interval_length,
                                       dbcfg.get_queries_per_transaction())) {
-    throw broker::exceptions::msg()
-        << "storage: Unable to initialize the storage connection to the database";
+    throw broker::exceptions::msg() << "storage: Unable to initialize the "
+                                       "storage connection to the database";
   }
 }
 

--- a/storage/src/stream.cc
+++ b/storage/src/stream.cc
@@ -66,11 +66,11 @@ stream::stream(database_config const& dbcfg,
                uint32_t rebuild_check_interval,
                bool store_in_db)
     : io::stream("storage"),
-      _pending_events(0)/*,
+      _pending_events(0),
       _rebuilder(dbcfg,
                  rebuild_check_interval,
                  rrd_len ? rrd_len : 15552000,
-                 interval_length)*/ {
+                 interval_length) {
   log_v2::sql()->debug("storage stream instanciation");
   if (!rrd_len)
     rrd_len = 15552000;

--- a/storage/src/stream.cc
+++ b/storage/src/stream.cc
@@ -77,7 +77,6 @@ stream::stream(database_config const& dbcfg,
 
   if (!conflict_manager::init_storage(store_in_db, rrd_len, interval_length,
                                       dbcfg.get_queries_per_transaction())) {
-    log_v2::sql()->trace("storage: Unable to initialize the storage connection");
     throw broker::exceptions::msg()
         << "storage: Unable to initialize the storage connection to the database";
   }
@@ -88,7 +87,7 @@ stream::stream(database_config const& dbcfg,
  */
 stream::~stream() {
   // Stop cleanup thread.
-  log_v2::sql()->debug("storage: stream destruction");
+  log_v2::sql()->trace("storage: stream destruction");
   conflict_manager::instance().unload(conflict_manager::storage);
 }
 

--- a/storage/src/stream.cc
+++ b/storage/src/stream.cc
@@ -87,7 +87,7 @@ stream::stream(database_config const& dbcfg,
 stream::~stream() {
   // Stop cleanup thread.
   log_v2::sql()->debug("storage: stream destruction");
-  conflict_manager::unload();
+  conflict_manager::instance().unload(conflict_manager::storage);
 }
 
 /**

--- a/storage/src/stream.cc
+++ b/storage/src/stream.cc
@@ -66,19 +66,21 @@ stream::stream(database_config const& dbcfg,
                uint32_t rebuild_check_interval,
                bool store_in_db)
     : io::stream("storage"),
-      _pending_events(0),
+      _pending_events(0)/*,
       _rebuilder(dbcfg,
                  rebuild_check_interval,
                  rrd_len ? rrd_len : 15552000,
-                 interval_length) {
+                 interval_length)*/ {
   log_v2::sql()->debug("storage stream instanciation");
   if (!rrd_len)
     rrd_len = 15552000;
 
   if (!conflict_manager::init_storage(store_in_db, rrd_len, interval_length,
-                                      dbcfg.get_queries_per_transaction()))
+                                      dbcfg.get_queries_per_transaction())) {
+    log_v2::sql()->trace("storage: Unable to initialize the storage connection");
     throw broker::exceptions::msg()
         << "storage: Unable to initialize the storage connection to the database";
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

This patch corrects many issues when Broker is badly configured and we want to stop it.
This patch also fixes the storage rebuilder mechanism.

REFS: MON-6369 ; MON-4952

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [X] 20.10.x
- [ ] 21.04.x (master)
