### PR TITLE
Mon 6785 bbdo categories

### DIFF
--- a/core/inc/com/centreon/broker/io/events.hh
+++ b/core/inc/com/centreon/broker/io/events.hh
@@ -41,14 +41,16 @@ class events {
   };
   typedef std::unordered_map<uint16_t, category_info> categories_container;
   // Reserved categories, for reference.
+  // Their values are very important to maintain the bbdo protocol retro
+  // compatible.
   enum data_category {
     neb = 1,
-    bbdo,
-    storage,
-    dumper,
-    bam,
-    extcmd,
-    generator,
+    bbdo = 2,
+    storage = 3,
+    dumper = 5,
+    bam = 6,
+    extcmd = 7,
+    generator = 8,
     internal = 65535
   };
   // Internal events used by the core.
@@ -70,7 +72,7 @@ class events {
   static void unload();
 
   // Category.
-  uint16_t register_category(std::string const& name, uint16_t hint = 0);
+  uint16_t register_category(std::string const& name, uint16_t hint);
   void unregister_category(uint16_t category_id);
 
   // Events.

--- a/core/test/bbdo/category.cc
+++ b/core/test/bbdo/category.cc
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2011 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "com/centreon/broker/io/events.hh"
+
+using namespace com::centreon::broker;
+
+/**
+ * @brief This test is very important, in case of a change in a category,
+ *        BBDO is no more compatible with previous versions.
+ *
+ * @param CategoryTest
+ * @param BbdoCategory
+ */
+TEST(CategoryTest, BbdoCategory) {
+  ASSERT_EQ(io::events::neb, 1);
+  ASSERT_EQ(io::events::bbdo, 2);
+  ASSERT_EQ(io::events::storage, 3);
+  ASSERT_EQ(io::events::dumper, 5);
+  ASSERT_EQ(io::events::bam, 6);
+  ASSERT_EQ(io::events::extcmd, 7);
+  ASSERT_EQ(io::events::generator, 8);
+  ASSERT_EQ(io::events::internal, 65535);
+}

--- a/core/test/bbdo/category.cc
+++ b/core/test/bbdo/category.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 - 2020 Centreon (https://www.centreon.com/)
+ * Copyright 2021 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(rpc_client berpc ${gRPC_LIBS} ${absl_LIBS} ${OpenSSL_LIBS}
 
 add_executable(ut
   # Core sources.
+  ${TESTS_DIR}/bbdo/category.cc
   ${TESTS_DIR}/bbdo/output.cc
   ${TESTS_DIR}/bbdo/read.cc
   ${TESTS_DIR}/ceof/ceof_parser/parse.cc


### PR DESCRIPTION
## Description

We the correlation module was removed, we accidentally changed categories numbers. This patch fixes them and is completed with a test.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x (master)
