### PR TITLE
fix(storage/lua): perfdata insertion more robust and logs more verbose

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 ##
-## Copyright 2009-2020 Centreon
+## Copyright 2009-2021 Centreon
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -1,5 +1,5 @@
 ##
-## Copyright 2018 Centreon
+## Copyright 2018-2021 Centreon
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ include_directories("${INC_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/bam/inc")
 include_directories("${PROJECT_SOURCE_DIR}/neb/inc")
 include_directories("${PROJECT_SOURCE_DIR}/storage/inc")
+include_directories("${PROJECT_SOURCE_DIR}/storage/inc")
+include_directories(${OpenSSL_INCLUDE_DIRS})
 set(INC_DIR "${INC_DIR}/com/centreon/broker/lua")
 
 # Storage module.

--- a/lua/src/broker_utils.cc
+++ b/lua/src/broker_utils.cc
@@ -21,6 +21,7 @@
 #include <fmt/format.h>
 #include <sys/stat.h>
 
+#include <openssl/md5.h>
 #include <cstdlib>
 #include <cstring>
 #include <iomanip>
@@ -219,18 +220,20 @@ static void broker_json_encode_broker_event(std::shared_ptr<io::data> e,
             }
             break;
           default:  // Error in one of the mappings.
-            throw msg_fmt("invalid mapping for object "
-                          "of type '{}': {}"
-                          " is not a known type ID",
-                          info->get_name(),
-                          current_entry->get_type());
+            throw msg_fmt(
+                "invalid mapping for object "
+                "of type '{}': {}"
+                " is not a known type ID",
+                info->get_name(), current_entry->get_type());
         }
       }
     }
     oss << "}";
   } else
-    throw msg_fmt("cannot bind object of type {}"
-                  " to database query: mapping does not exist", e->type());
+    throw msg_fmt(
+        "cannot bind object of type {}"
+        " to database query: mapping does not exist",
+        e->type());
 }
 
 /**
@@ -434,7 +437,7 @@ static int l_broker_parse_perfdata(lua_State* L) {
   storage::parser p;
   std::list<storage::perfdata> pds;
   try {
-    p.parse_perfdata(perf_data, pds);
+    p.parse_perfdata(0, 0, perf_data, pds);
   } catch (storage::exceptions::perfdata const& e) {
     lua_pushnil(L);
     lua_pushstring(L, e.what());
@@ -542,6 +545,31 @@ static int l_broker_stat(lua_State* L) {
   }
 }
 
+static int l_broker_md5(lua_State* L) {
+  auto digit = [](unsigned char d) -> char {
+    if (d < 10)
+      return '0' + d;
+    else
+      return 'a' + (d - 10);
+  };
+  size_t len;
+  const unsigned char* str =
+      reinterpret_cast<const unsigned char*>(lua_tolstring(L, -1, &len));
+  unsigned char md5[MD5_DIGEST_LENGTH];
+  MD5(str, len, md5);
+  char result[2 * MD5_DIGEST_LENGTH + 1];
+  char* tmp = result;
+  for (int i = 0; i < MD5_DIGEST_LENGTH; i++) {
+    *tmp = digit(md5[i] >> 4);
+    ++tmp;
+    *tmp = digit(md5[i] & 0xf);
+    ++tmp;
+  }
+  *tmp = 0;
+  lua_pushstring(L, result);
+  return 1;
+}
+
 /**
  *  Load the Lua interpreter with the standard libraries
  *  and the broker lua sdk.
@@ -554,6 +582,7 @@ void broker_utils::broker_utils_reg(lua_State* L) {
                               {"parse_perfdata", l_broker_parse_perfdata},
                               {"url_encode", l_broker_url_encode},
                               {"stat", l_broker_stat},
+                              {"md5", l_broker_md5},
                               {nullptr, nullptr}};
 
 #ifdef LUA51

--- a/sql/inc/com/centreon/broker/sql/stream.hh
+++ b/sql/inc/com/centreon/broker/sql/stream.hh
@@ -49,7 +49,7 @@ class stream : public io::stream {
   database::mysql_stmt _issue_parent_insert;
   database::mysql_stmt _issue_parent_update;
   database::mysql_stmt _service_state_insupdate;
-//  cleanup _cleanup_thread;
+  //  cleanup _cleanup_thread;
   int _pending_events;
   bool _with_state_events;
   mutable std::mutex _stat_mutex;
@@ -65,12 +65,11 @@ class stream : public io::stream {
   stream(stream const& other) = delete;
   stream& operator=(stream const& other) = delete;
   ~stream();
-  int flush();
-  bool read(std::shared_ptr<io::data>& d, time_t deadline);
-  void update();
-  int write(std::shared_ptr<io::data> const& d);
+  int flush() override;
+  bool read(std::shared_ptr<io::data>& d, time_t deadline) override;
+  void update() override;
+  int write(std::shared_ptr<io::data> const& d) override;
   void statistics(json11::Json::object& tree) const override;
-
 };
 }  // namespace sql
 

--- a/storage/inc/com/centreon/broker/storage/parser.hh
+++ b/storage/inc/com/centreon/broker/storage/parser.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2013 Centreon
+** Copyright 2011-2013, 2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -37,11 +37,14 @@ namespace storage {
  */
 class parser {
  public:
-  parser();
+  parser() = default;
+  ~parser() noexcept = default;
   parser(parser const& p) = delete;
-  ~parser();
   parser& operator=(parser const& p) = delete;
-  void parse_perfdata(const char* str, std::list<perfdata>& pd);
+  void parse_perfdata(uint32_t host_id,
+                      uint32_t service_id,
+                      const char* str,
+                      std::list<perfdata>& pd);
 };
 }  // namespace storage
 

--- a/storage/inc/com/centreon/broker/storage/stream.hh
+++ b/storage/inc/com/centreon/broker/storage/stream.hh
@@ -86,10 +86,10 @@ class stream : public io::stream {
   stream(stream const&) = delete;
   stream& operator=(stream const&) = delete;
   ~stream();
-  int32_t flush();
-  bool read(std::shared_ptr<io::data>& d, time_t deadline);
+  int32_t flush() override;
+  bool read(std::shared_ptr<io::data>& d, time_t deadline) override;
   void statistics(json11::Json::object& tree) const override;
-  int32_t write(std::shared_ptr<io::data> const& d);
+  int32_t write(std::shared_ptr<io::data> const& d) override;
 };
 }  // namespace storage
 

--- a/storage/src/conflict_manager_sql.cc
+++ b/storage/src/conflict_manager_sql.cc
@@ -1566,7 +1566,7 @@ void conflict_manager::_process_service(
                          actions::service_dependencies);
 
   // Processed object.
-  neb::service const& s(*static_cast<neb::service const*>(d.get()));
+  const neb::service& s(*static_cast<neb::service const*>(d.get()));
   if (_cache_host_instance[s.host_id]) {
     int32_t conn =
         _mysql.choose_connection_by_instance(_cache_host_instance[s.host_id]);

--- a/storage/test/perfdata.cc
+++ b/storage/test/perfdata.cc
@@ -209,7 +209,8 @@ TEST_F(StorageParserParsePerfdata, Simple1) {
   // Parse perfdata.
   std::list<storage::perfdata> lst;
   storage::parser p;
-  p.parse_perfdata("time=2.45698s;2.000000;5.000000;0.000000;10.000000", lst);
+  p.parse_perfdata(0, 0, "time=2.45698s;2.000000;5.000000;0.000000;10.000000",
+                   lst);
 
   // Assertions.
   ASSERT_EQ(lst.size(), 1u);
@@ -232,7 +233,7 @@ TEST_F(StorageParserParsePerfdata, Simple2) {
   // Parse perfdata.
   std::list<storage::perfdata> list;
   storage::parser p;
-  p.parse_perfdata("'ABCD12E'=18.00%;15:;10:;0;100", list);
+  p.parse_perfdata(0, 0, "'ABCD12E'=18.00%;15:;10:;0;100", list);
 
   // Assertions.
   ASSERT_EQ(list.size(), 1u);
@@ -256,6 +257,7 @@ TEST_F(StorageParserParsePerfdata, Complex1) {
   std::list<storage::perfdata> list;
   storage::parser p;
   p.parse_perfdata(
+      0, 0,
       "time=2.45698s;;nan;;inf d[metric]=239765B/s;5;;-inf; "
       "infotraffic=18x;;;; a[foo]=1234;10;11: c[bar]=1234;~:10;20:30 "
       "baz=1234;@10:20; 'q u x'=9queries_per_second;@10:;@5:;0;100",
@@ -360,8 +362,8 @@ TEST_F(StorageParserParsePerfdata, Loop) {
   for (uint32_t i(0); i < 10000; ++i) {
     // Parse perfdata string.
     list.clear();
-    p.parse_perfdata("c[time]=2.45698s;2.000000;5.000000;0.000000;10.000000",
-                     list);
+    p.parse_perfdata(
+        0, 0, "c[time]=2.45698s;2.000000;5.000000;0.000000;10.000000", list);
 
     // Assertions.
     ASSERT_EQ(list.size(), 1u);
@@ -391,7 +393,7 @@ TEST_F(StorageParserParsePerfdata, Incorrect1) {
   storage::parser p;
 
   // Attempt to parse perfdata.
-  p.parse_perfdata("metric1= 10 metric2=42", list);
+  p.parse_perfdata(0, 0, "metric1= 10 metric2=42", list);
   ASSERT_EQ(list.size(), 1);
   ASSERT_EQ(list.back().name(), "metric2");
   ASSERT_EQ(list.back().value(), 42);
@@ -406,7 +408,7 @@ TEST_F(StorageParserParsePerfdata, Incorrect2) {
   storage::parser p;
 
   // Then
-  p.parse_perfdata("metric=kb/s", list);
+  p.parse_perfdata(0, 0, "metric=kb/s", list);
   ASSERT_TRUE(list.empty());
 }
 
@@ -414,7 +416,7 @@ TEST_F(StorageParserParsePerfdata, LabelWithSpaces) {
   // Parse perfdata.
   std::list<storage::perfdata> lst;
   storage::parser p;
-  p.parse_perfdata("  'foo  bar   '=2s;2;5;;", lst);
+  p.parse_perfdata(0, 0, "  'foo  bar   '=2s;2;5;;", lst);
 
   // Assertions.
   ASSERT_EQ(lst.size(), 1u);
@@ -435,7 +437,7 @@ TEST_F(StorageParserParsePerfdata, LabelWithSpacesMultiline) {
   // Parse perfdata.
   std::list<storage::perfdata> lst;
   storage::parser p;
-  p.parse_perfdata("  'foo  bar   '=2s;2;5;;", lst);
+  p.parse_perfdata(0, 0, "  'foo  bar   '=2s;2;5;;", lst);
 
   // Assertions.
   ASSERT_EQ(lst.size(), 1u);
@@ -457,6 +459,7 @@ TEST_F(StorageParserParsePerfdata, Complex2) {
   std::list<storage::perfdata> list;
   storage::parser p;
   p.parse_perfdata(
+      0, 0,
       "'  \n time'=2,45698s;;nan;;inf d[metric]=239765B/s;5;;-inf; "
       "g[test]=8x;;;;"
       " infotraffic=18,6x;;;; a[foo]=1234,17;10;11: c[bar]=1234,147;~:10;20:30",
@@ -545,7 +548,7 @@ TEST_F(StorageParserParsePerfdata, SimpleWithR) {
   std::list<storage::perfdata> lst;
   storage::parser p;
   // ASSERT_NO_THROW(p.parse_perfdata("'total'=5;;;0;\r", lst));
-  ASSERT_NO_THROW(p.parse_perfdata("'total'=5;;;0;\r", lst));
+  ASSERT_NO_THROW(p.parse_perfdata(0, 0, "'total'=5;;;0;\r", lst));
 
   // Assertions.
   ASSERT_EQ(lst.size(), 1u);
@@ -571,7 +574,7 @@ TEST_F(StorageParserParsePerfdata, BadMetric) {
   // Parse perfdata.
   std::list<storage::perfdata> lst;
   storage::parser p;
-  ASSERT_NO_THROW(p.parse_perfdata("user1=1 user2=2 =1 user3=3", lst));
+  ASSERT_NO_THROW(p.parse_perfdata(0, 0, "user1=1 user2=2 =1 user3=3", lst));
 
   // Assertions.
   ASSERT_EQ(lst.size(), 3u);
@@ -587,7 +590,8 @@ TEST_F(StorageParserParsePerfdata, BadMetric1) {
   // Parse perfdata.
   std::list<storage::perfdata> lst;
   storage::parser p;
-  ASSERT_NO_THROW(p.parse_perfdata("user1=1 user2=2 user4= user3=3", lst));
+  ASSERT_NO_THROW(
+      p.parse_perfdata(0, 0, "user1=1 user2=2 user4= user3=3", lst));
 
   // Assertions.
   ASSERT_EQ(lst.size(), 3u);


### PR DESCRIPTION
## Description

* insertion of perfdata in database more robust. Values can be NaN or Inf. In that case, a NULL value is inserted instead.
* when the perfdata parser fails, it logs an error with the (host_id,service_id) of the associated service so it is easier for user to debug his checks.
* the streamconnector provides a new function broker.md5(str) that returns the md5 sum of the string str.

REFS: MON-6915 MON-6918

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x (master)
