### PR TITLE
Mon 6915 log details metrics insertion 20.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 ### Bugfixes
 
+*streamconnector*
+
+There is a new function broker.md5(str) provided by the streamconnector that
+computes the md5 checksum of the given string str.
+
+*perfdata*
+
+If a perfdata contains infinity or nan values, its insertion in database could
+fail. This fixed now by inserting a NULL value instead. When the perfdata parser
+encounters an error during its work, now it returns logs with the host id and
+the service id of the associated service, so it is easier for the user to debug
+his check.
+
 *Log file configuration*
 
 log file configuration is applied even if the configuration contains errors.
@@ -23,7 +36,7 @@ correctly.
 
 *Logs*
 
-The new logs (log_v2) are correctly flushed when cbd is stopped.
+The new logs (log\_v2) are correctly flushed when cbd is stopped.
 
 *Thread pool*
 

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -1,5 +1,5 @@
 ##
-## Copyright 2018 Centreon
+## Copyright 2018-2021 Centreon
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ include_directories("${INC_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/bam/inc")
 include_directories("${PROJECT_SOURCE_DIR}/neb/inc")
 include_directories("${PROJECT_SOURCE_DIR}/storage/inc")
+include_directories("${PROJECT_SOURCE_DIR}/storage/inc")
+include_directories(${OpenSSL_INCLUDE_DIRS})
 set(INC_DIR "${INC_DIR}/com/centreon/broker/lua")
 
 # Storage module.

--- a/lua/test/lua.cc
+++ b/lua/test/lua.cc
@@ -171,23 +171,24 @@ TEST_F(LuaTest, SimpleScript) {
   l.load_file("./neb/10-neb.so");
 
   std::string filename("/tmp/test-lua3.lua");
-  CreateScript(filename,
-"broker_api_version = 2\n"
-"function init(params)\n"
-"  broker_log:set_parameters(1, \"/tmp/test.log\")\n"
-"  for i,v in pairs(params) do\n"
-"    broker_log:info(1, \"init: \" .. i .. \" => \" .. tostring(v))\n"
-"  end\n"
-"end\n"
-"function write(d)\n"
-"  for i,v in pairs(d) do\n"
-"    broker_log:info(1, \"write: \" .. i .. \" => \" .. tostring(v))\n"
-"  end\n"
-"  return true\n"
-"end\n"
-"function filter(typ, cat)\n"
-"  return true\n"
-"end\n");
+  CreateScript(
+      filename,
+      "broker_api_version = 2\n"
+      "function init(params)\n"
+      "  broker_log:set_parameters(1, \"/tmp/test.log\")\n"
+      "  for i,v in pairs(params) do\n"
+      "    broker_log:info(1, \"init: \" .. i .. \" => \" .. tostring(v))\n"
+      "  end\n"
+      "end\n"
+      "function write(d)\n"
+      "  for i,v in pairs(d) do\n"
+      "    broker_log:info(1, \"write: \" .. i .. \" => \" .. tostring(v))\n"
+      "  end\n"
+      "  return true\n"
+      "end\n"
+      "function filter(typ, cat)\n"
+      "  return true\n"
+      "end\n");
 
   std::unique_ptr<luabinding> bnd(new luabinding(filename, conf, *_cache));
   ASSERT_TRUE(bnd.get());
@@ -2064,3 +2065,46 @@ TEST_F(LuaTest, BrokerEventCache) {
   RemoveFile("/tmp/event_log");
 }
 
+// When the user needs the md5 sum of a string, he can use the md5 function
+// that returns it as a string with hexadecimal number.
+TEST_F(LuaTest, md5) {
+  std::map<std::string, misc::variant> conf;
+  std::string filename("/tmp/md5.lua");
+  CreateScript(filename,
+               "function init(conf)\n"
+               "  broker_log:set_parameters(3, '/tmp/log')\n"
+               "  local info = broker.md5('Hello World!')\n"
+               "  broker_log:info(1, info)\n"
+               "end\n"
+               "function write(d)\n"
+               "  return true\n"
+               "end");
+  std::unique_ptr<luabinding> binding(new luabinding(filename, conf, *_cache));
+  std::string result(ReadFile("/tmp/log"));
+  ASSERT_NE(result.find("ed076287532e86365e841e92bfc50d8c"), std::string::npos);
+
+  RemoveFile(filename);
+  RemoveFile("/tmp/log");
+}
+
+// When the user needs the md5 sum of a string, he can use the md5 function
+// that returns it as a string with hexadecimal number.
+TEST_F(LuaTest, emptyMd5) {
+  std::map<std::string, misc::variant> conf;
+  std::string filename("/tmp/md5.lua");
+  CreateScript(filename,
+               "function init(conf)\n"
+               "  broker_log:set_parameters(3, '/tmp/log')\n"
+               "  local info = broker.md5('')\n"
+               "  broker_log:info(1, info)\n"
+               "end\n"
+               "function write(d)\n"
+               "  return true\n"
+               "end");
+  std::unique_ptr<luabinding> binding(new luabinding(filename, conf, *_cache));
+  std::string result(ReadFile("/tmp/log"));
+  ASSERT_NE(result.find("d41d8cd98f00b204e9800998ecf8427e"), std::string::npos);
+
+  RemoveFile(filename);
+  RemoveFile("/tmp/log");
+}

--- a/sql/inc/com/centreon/broker/sql/stream.hh
+++ b/sql/inc/com/centreon/broker/sql/stream.hh
@@ -49,7 +49,7 @@ class stream : public io::stream {
   database::mysql_stmt _issue_parent_insert;
   database::mysql_stmt _issue_parent_update;
   database::mysql_stmt _service_state_insupdate;
-//  cleanup _cleanup_thread;
+  //  cleanup _cleanup_thread;
   int _pending_events;
   bool _with_state_events;
   mutable std::mutex _stat_mutex;
@@ -75,12 +75,11 @@ class stream : public io::stream {
   stream(stream const& other) = delete;
   stream& operator=(stream const& other) = delete;
   ~stream();
-  int flush();
-  bool read(std::shared_ptr<io::data>& d, time_t deadline);
-  void update();
-  int write(std::shared_ptr<io::data> const& d);
+  int flush() override;
+  bool read(std::shared_ptr<io::data>& d, time_t deadline) override;
+  void update() override;
+  int write(std::shared_ptr<io::data> const& d) override;
   void statistics(json11::Json::object& tree) const override;
-
 };
 }  // namespace sql
 

--- a/storage/inc/com/centreon/broker/storage/parser.hh
+++ b/storage/inc/com/centreon/broker/storage/parser.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2013 Centreon
+** Copyright 2011-2013, 2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -37,11 +37,14 @@ namespace storage {
  */
 class parser {
  public:
-  parser();
+  parser() = default;
+  ~parser() noexcept = default;
   parser(parser const& p) = delete;
-  ~parser();
   parser& operator=(parser const& p) = delete;
-  void parse_perfdata(const char* str, std::list<perfdata>& pd);
+  void parse_perfdata(uint32_t host_id,
+                      uint32_t service_id,
+                      const char* str,
+                      std::list<perfdata>& pd);
 };
 }  // namespace storage
 

--- a/storage/inc/com/centreon/broker/storage/stream.hh
+++ b/storage/inc/com/centreon/broker/storage/stream.hh
@@ -86,10 +86,10 @@ class stream : public io::stream {
   stream(stream const&) = delete;
   stream& operator=(stream const&) = delete;
   ~stream();
-  int32_t flush();
-  bool read(std::shared_ptr<io::data>& d, time_t deadline);
+  int32_t flush() override;
+  bool read(std::shared_ptr<io::data>& d, time_t deadline) override;
   void statistics(json11::Json::object& tree) const override;
-  int32_t write(std::shared_ptr<io::data> const& d);
+  int32_t write(std::shared_ptr<io::data> const& d) override;
 };
 }  // namespace storage
 

--- a/storage/src/conflict_manager_sql.cc
+++ b/storage/src/conflict_manager_sql.cc
@@ -1567,7 +1567,7 @@ void conflict_manager::_process_service(
                          actions::service_dependencies);
 
   // Processed object.
-  neb::service const& s(*static_cast<neb::service const*>(d.get()));
+  const neb::service& s(*static_cast<neb::service const*>(d.get()));
   if (_cache_host_instance[s.host_id]) {
     int32_t conn =
         _mysql.choose_connection_by_instance(_cache_host_instance[s.host_id]);

--- a/storage/src/conflict_manager_storage.cc
+++ b/storage/src/conflict_manager_storage.cc
@@ -254,7 +254,7 @@ void conflict_manager::_storage_process_service_status(
       storage::parser p;
       try {
         _finish_action(-1, actions::metrics);
-        p.parse_perfdata(ss.perf_data.c_str(), pds);
+        p.parse_perfdata(ss.host_id, ss.service_id, ss.perf_data.c_str(), pds);
 
         std::list<std::shared_ptr<io::data>> to_publish;
         for (auto& pd : pds) {
@@ -426,17 +426,29 @@ void conflict_manager::_update_metrics() {
         "({},'{}',{},{},'{}',{},{},'{}',{},{},{})", metric->metric_id,
         misc::string::escape(metric->unit_name,
                              get_metrics_col_size(metrics_unit_name)),
-        std::isnan(metric->warn) ? "NULL" : fmt::format("{}", metric->warn),
-        std::isnan(metric->warn_low) ? "NULL"
-                                     : fmt::format("{}", metric->warn_low),
+        std::isnan(metric->warn) || std::isinf(metric->warn)
+            ? "NULL"
+            : fmt::format("{}", metric->warn),
+        std::isnan(metric->warn_low) || std::isinf(metric->warn_low)
+            ? "NULL"
+            : fmt::format("{}", metric->warn_low),
         metric->warn_mode ? "1" : "0",
-        std::isnan(metric->crit) ? "NULL" : fmt::format("{}", metric->crit),
-        std::isnan(metric->crit_low) ? "NULL"
-                                     : fmt::format("{}", metric->crit_low),
+        std::isnan(metric->crit) || std::isinf(metric->crit)
+            ? "NULL"
+            : fmt::format("{}", metric->crit),
+        std::isnan(metric->crit_low) || std::isinf(metric->crit_low)
+            ? "NULL"
+            : fmt::format("{}", metric->crit_low),
         metric->crit_mode ? "1" : "0",
-        std::isnan(metric->min) ? "NULL" : fmt::format("{}", metric->min),
-        std::isnan(metric->max) ? "NULL" : fmt::format("{}", metric->max),
-        metric->value));
+        std::isnan(metric->min) || std::isinf(metric->min)
+            ? "NULL"
+            : fmt::format("{}", metric->min),
+        std::isnan(metric->max) || std::isinf(metric->max)
+            ? "NULL"
+            : fmt::format("{}", metric->max),
+        std::isnan(metric->value) || std::isinf(metric->value)
+            ? "NULL"
+            : fmt::format("{}", metric->value)));
   }
   std::string query(fmt::format(
       "INSERT INTO metrics (metric_id, unit_name, warn, warn_low, "

--- a/storage/test/perfdata.cc
+++ b/storage/test/perfdata.cc
@@ -227,7 +227,8 @@ TEST_F(StorageParserParsePerfdata, Simple1) {
   // Parse perfdata.
   std::list<storage::perfdata> lst;
   storage::parser p;
-  p.parse_perfdata("time=2.45698s;2.000000;5.000000;0.000000;10.000000", lst);
+  p.parse_perfdata(0, 0, "time=2.45698s;2.000000;5.000000;0.000000;10.000000",
+                   lst);
 
   // Assertions.
   ASSERT_EQ(lst.size(), 1u);
@@ -250,7 +251,7 @@ TEST_F(StorageParserParsePerfdata, Simple2) {
   // Parse perfdata.
   std::list<storage::perfdata> list;
   storage::parser p;
-  p.parse_perfdata("'ABCD12E'=18.00%;15:;10:;0;100", list);
+  p.parse_perfdata(0, 0, "'ABCD12E'=18.00%;15:;10:;0;100", list);
 
   // Assertions.
   ASSERT_EQ(list.size(), 1u);
@@ -274,6 +275,7 @@ TEST_F(StorageParserParsePerfdata, Complex1) {
   std::list<storage::perfdata> list;
   storage::parser p;
   p.parse_perfdata(
+      0, 0,
       "time=2.45698s;;nan;;inf d[metric]=239765B/s;5;;-inf; "
       "infotraffic=18x;;;; a[foo]=1234;10;11: c[bar]=1234;~:10;20:30 "
       "baz=1234;@10:20; 'q u x'=9queries_per_second;@10:;@5:;0;100",
@@ -378,8 +380,8 @@ TEST_F(StorageParserParsePerfdata, Loop) {
   for (uint32_t i(0); i < 10000; ++i) {
     // Parse perfdata string.
     list.clear();
-    p.parse_perfdata("c[time]=2.45698s;2.000000;5.000000;0.000000;10.000000",
-                     list);
+    p.parse_perfdata(
+        0, 0, "c[time]=2.45698s;2.000000;5.000000;0.000000;10.000000", list);
 
     // Assertions.
     ASSERT_EQ(list.size(), 1u);
@@ -409,7 +411,7 @@ TEST_F(StorageParserParsePerfdata, Incorrect1) {
   storage::parser p;
 
   // Attempt to parse perfdata.
-  p.parse_perfdata("metric1= 10 metric2=42", list);
+  p.parse_perfdata(0, 0, "metric1= 10 metric2=42", list);
   ASSERT_EQ(list.size(), 1);
   ASSERT_EQ(list.back().name(), "metric2");
   ASSERT_EQ(list.back().value(), 42);
@@ -424,7 +426,7 @@ TEST_F(StorageParserParsePerfdata, Incorrect2) {
   storage::parser p;
 
   // Then
-  p.parse_perfdata("metric=kb/s", list);
+  p.parse_perfdata(0, 0, "metric=kb/s", list);
   ASSERT_TRUE(list.empty());
 }
 
@@ -432,7 +434,7 @@ TEST_F(StorageParserParsePerfdata, LabelWithSpaces) {
   // Parse perfdata.
   std::list<storage::perfdata> lst;
   storage::parser p;
-  p.parse_perfdata("  'foo  bar   '=2s;2;5;;", lst);
+  p.parse_perfdata(0, 0, "  'foo  bar   '=2s;2;5;;", lst);
 
   // Assertions.
   ASSERT_EQ(lst.size(), 1u);
@@ -453,7 +455,7 @@ TEST_F(StorageParserParsePerfdata, LabelWithSpacesMultiline) {
   // Parse perfdata.
   std::list<storage::perfdata> lst;
   storage::parser p;
-  p.parse_perfdata("  'foo  bar   '=2s;2;5;;", lst);
+  p.parse_perfdata(0, 0, "  'foo  bar   '=2s;2;5;;", lst);
 
   // Assertions.
   ASSERT_EQ(lst.size(), 1u);
@@ -475,6 +477,7 @@ TEST_F(StorageParserParsePerfdata, Complex2) {
   std::list<storage::perfdata> list;
   storage::parser p;
   p.parse_perfdata(
+      0, 0,
       "'  \n time'=2,45698s;;nan;;inf d[metric]=239765B/s;5;;-inf; "
       "g[test]=8x;;;;"
       " infotraffic=18,6x;;;; a[foo]=1234,17;10;11: c[bar]=1234,147;~:10;20:30",
@@ -563,7 +566,7 @@ TEST_F(StorageParserParsePerfdata, SimpleWithR) {
   std::list<storage::perfdata> lst;
   storage::parser p;
   // ASSERT_NO_THROW(p.parse_perfdata("'total'=5;;;0;\r", lst));
-  ASSERT_NO_THROW(p.parse_perfdata("'total'=5;;;0;\r", lst));
+  ASSERT_NO_THROW(p.parse_perfdata(0, 0, "'total'=5;;;0;\r", lst));
 
   // Assertions.
   ASSERT_EQ(lst.size(), 1u);
@@ -589,7 +592,7 @@ TEST_F(StorageParserParsePerfdata, BadMetric) {
   // Parse perfdata.
   std::list<storage::perfdata> lst;
   storage::parser p;
-  ASSERT_NO_THROW(p.parse_perfdata("user1=1 user2=2 =1 user3=3", lst));
+  ASSERT_NO_THROW(p.parse_perfdata(0, 0, "user1=1 user2=2 =1 user3=3", lst));
 
   // Assertions.
   ASSERT_EQ(lst.size(), 3u);
@@ -605,7 +608,8 @@ TEST_F(StorageParserParsePerfdata, BadMetric1) {
   // Parse perfdata.
   std::list<storage::perfdata> lst;
   storage::parser p;
-  ASSERT_NO_THROW(p.parse_perfdata("user1=1 user2=2 user4= user3=3", lst));
+  ASSERT_NO_THROW(
+      p.parse_perfdata(0, 0, "user1=1 user2=2 user4= user3=3", lst));
 
   // Assertions.
   ASSERT_EQ(lst.size(), 3u);


### PR DESCRIPTION
## Description

* insertion of perfdata in database more robust. Values can be NaN or Inf. In that case, a NULL value is inserted instead.
* when the perfdata parser fails, it logs an error with the (host_id,service_id) of the associated service so it is easier for user to debug his checks.
* the streamconnector provides a new function broker.md5(str) that returns the md5 sum of the string str.

REFS: MON-6915 MON-6918

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [X] 20.10.x
- [ ] 21.04.x (master)
