### PR TITLE
Mon 6393 close wait 20.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ have been removed.
 
 ### Bugfixes
 
+*TCP*
+
+If we have an issue on the network between cbd and centengine, it is possible
+that the acceptor among them keeps for an indefined time its connections to the
+other. This leads to socket in CLOSE\_WAIT state.
+
 *streamconnector*
 
 There is a new function broker.md5(str) provided by the streamconnector that

--- a/core/src/compression/stream.cc
+++ b/core/src/compression/stream.cc
@@ -73,7 +73,7 @@ bool stream::read(std::shared_ptr<io::data>& data, time_t deadline) {
     // Process buffer as long as data is corrupted
     // or until an exception occurs.
     bool corrupted(true);
-    int size(0);
+    size_t size(0);
     int skipped(0);
     while (corrupted) {
       // Get compressed data length.

--- a/core/src/mapping/entry.cc
+++ b/core/src/mapping/entry.cc
@@ -28,7 +28,6 @@ using namespace com::centreon::broker::mapping;
  *                                     *
  **************************************/
 
-
 /**
  *  Get the boolean value.
  *

--- a/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
+++ b/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Centreon
+** Copyright 2020-2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -70,8 +70,8 @@ class tcp_async {
   asio::steady_timer _timer;
   std::atomic_bool _clear_available_con_running;
 
-  tcp_async(): _timer(pool::instance().io_context()), _clear_available_con_running(false) {}
-  ~tcp_async() noexcept = default;
+  tcp_async();
+  ~tcp_async() noexcept;
 
   void _clear_available_con(asio::error_code ec);
 

--- a/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
+++ b/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
@@ -18,17 +18,44 @@
 #ifndef CENTREON_BROKER_TCP_INC_COM_CENTREON_BROKER_TCP_TCP_ASYNC_HH_
 #define CENTREON_BROKER_TCP_INC_COM_CENTREON_BROKER_TCP_TCP_ASYNC_HH_
 
-#include <asio.hpp>
 #include <list>
 #include <queue>
 #include <thread>
 #include <unordered_map>
 
+#include "com/centreon/broker/pool.hh"
 #include "com/centreon/broker/tcp/tcp_connection.hh"
 
 CCB_BEGIN()
 namespace tcp {
 
+/**
+ * @brief The tcp_async class.
+ *
+ * This class does several little things in background to establish, shutdown,
+ * clear connections.
+ *
+ * TCP acceptors do their job here with essentially two methods:
+ * * start_acceptor()
+ * * stop_acceptor()
+ *
+ * When an acceptor gets a connection, this one is stored in a multimap named
+ * _acceptor_available_con.
+ *
+ * Each time, broker gets one of those available connections, they also are
+ * removed from this multimap.
+ *
+ * If a connection stays a too long time in this multimap, it is probably
+ * a dead connection (usually, the connector asks for a connection, the acceptor
+ * accepts it, but this is done asynchronously. Then the connector starts to
+ * negotiate and sometimes, the acceptor does not have time at this instant, so
+ * the negotiation fails. The connector throws away the connection but not the
+ * acceptor because it does not know about this negotiation attempt).
+ *
+ * Then each time an acceptor is started, a timer is started, it asynchronously
+ * waits for 10s, and then looks if there are not used connections established
+ * for more than 4s. In that case, it removes them.
+ */
 class tcp_async {
   /* The acceptors open by this tcp_async */
   std::list<std::shared_ptr<asio::ip::tcp::acceptor>> _acceptor;
@@ -40,8 +67,13 @@ class tcp_async {
                           std::pair<tcp_connection::pointer, time_t>>
       _acceptor_available_con;
 
-  tcp_async() = default;
+  asio::steady_timer _timer;
+  std::atomic_bool _clear_available_con_running;
+
+  tcp_async(): _timer(pool::instance().io_context()), _clear_available_con_running(false) {}
   ~tcp_async() noexcept = default;
+
+  void _clear_available_con(asio::error_code ec);
 
  public:
   static tcp_async& instance();

--- a/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
+++ b/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
@@ -36,7 +36,8 @@ class tcp_async {
   /* Connections opened by acceptors not already got by streams */
   mutable std::mutex _acceptor_con_m;
   std::condition_variable _acceptor_con_cv;
-  std::unordered_multimap<asio::ip::tcp::acceptor*, tcp_connection::pointer>
+  std::unordered_multimap<asio::ip::tcp::acceptor*,
+                          std::pair<tcp_connection::pointer, time_t>>
       _acceptor_available_con;
 
   tcp_async() = default;

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -90,6 +90,7 @@ std::shared_ptr<asio::ip::tcp::acceptor> tcp_async::create_acceptor(
 }
 
 void tcp_async::_clear_available_con(asio::error_code ec) {
+  log_v2::core()->info("Clearing old connections");
   if (ec)
     log_v2::core()->info("The clear mechanism for available connections encountered an error: {}",
                          ec.message());
@@ -117,9 +118,9 @@ void tcp_async::_clear_available_con(asio::error_code ec) {
  */
 void tcp_async::start_acceptor(
     std::shared_ptr<asio::ip::tcp::acceptor> acceptor) {
-  _timer.expires_after(std::chrono::seconds(10));
   if (!_clear_available_con_running) {
     _clear_available_con_running = true;
+    _timer.expires_after(std::chrono::seconds(10));
     _timer.async_wait(
         std::bind(&tcp_async::_clear_available_con, this, std::placeholders::_1));
   }

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -89,6 +89,26 @@ std::shared_ptr<asio::ip::tcp::acceptor> tcp_async::create_acceptor(
   return retval;
 }
 
+void tcp_async::_clear_available_con(asio::error_code ec) {
+  if (ec)
+    log_v2::core()->info("The clear mechanism for available connections encountered an error: {}",
+                         ec.message());
+  else {
+    std::unique_lock<std::mutex> lck(_acceptor_con_m);
+    std::time_t now = std::time(nullptr);
+    for (auto it = _acceptor_available_con.begin();
+         it != _acceptor_available_con.end(); ) {
+      if (now >= it->second.second + 4) {
+        log_v2::tcp()->info("Destroying too old/not used connection '{}'",
+                            it->second.first->peer());
+        it = _acceptor_available_con.erase(it);
+      } else
+        ++it;
+    }
+  }
+  _clear_available_con_running = false;
+}
+
 /**
  * @brief Starts the acceptor given in parameter. To accept the acceptor needs
  * the IO Context to be running.
@@ -97,16 +117,13 @@ std::shared_ptr<asio::ip::tcp::acceptor> tcp_async::create_acceptor(
  */
 void tcp_async::start_acceptor(
     std::shared_ptr<asio::ip::tcp::acceptor> acceptor) {
-  std::time_t now = std::time(nullptr);
-  for (auto it = _acceptor_available_con.begin();
-       it != _acceptor_available_con.end(); ) {
-    if (now >= it->second.second + 4) {
-      log_v2::tcp()->info("Destroying too old/not used connection '{}'",
-                          it->second.first->peer());
-      it = _acceptor_available_con.erase(it);
-    } else
-      ++it;
+  _timer.expires_after(std::chrono::seconds(10));
+  if (!_clear_available_con_running) {
+    _clear_available_con_running = true;
+    _timer.async_wait(
+        std::bind(&tcp_async::_clear_available_con, this, std::placeholders::_1));
   }
+
   tcp_connection::pointer new_connection =
       std::make_shared<tcp_connection>(pool::io_context());
 

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -36,6 +36,23 @@ tcp_async& tcp_async::instance() {
   return instance;
 }
 
+tcp_async::tcp_async()
+      : _timer(pool::instance().io_context()),
+        _clear_available_con_running(false) {}
+
+tcp_async::~tcp_async() noexcept {
+  if (_clear_available_con_running) {
+    std::promise<bool> p;
+    std::future<bool> f(p.get_future());
+    _stats_running = false;
+    asio::post(_timer.get_executor(), [this, &p] {
+        _timer.cancel();
+        p.set_value(true);
+        });
+    f.get();
+  }
+}
+
 /**
  * @brief If the acceptor given in parameter has established a connection.
  * This method returns it. Otherwise, it returns an empty connection.
@@ -92,13 +109,15 @@ std::shared_ptr<asio::ip::tcp::acceptor> tcp_async::create_acceptor(
 void tcp_async::_clear_available_con(asio::error_code ec) {
   log_v2::core()->info("Clearing old connections");
   if (ec)
-    log_v2::core()->info("The clear mechanism for available connections encountered an error: {}",
-                         ec.message());
+    log_v2::core()->info(
+        "The clear mechanism for available connections encountered an error: "
+        "{}",
+        ec.message());
   else {
     std::unique_lock<std::mutex> lck(_acceptor_con_m);
     std::time_t now = std::time(nullptr);
     for (auto it = _acceptor_available_con.begin();
-         it != _acceptor_available_con.end(); ) {
+         it != _acceptor_available_con.end();) {
       if (now >= it->second.second + 4) {
         log_v2::tcp()->info("Destroying too old/not used connection '{}'",
                             it->second.first->peer());
@@ -121,8 +140,8 @@ void tcp_async::start_acceptor(
   if (!_clear_available_con_running) {
     _clear_available_con_running = true;
     _timer.expires_after(std::chrono::seconds(10));
-    _timer.async_wait(
-        std::bind(&tcp_async::_clear_available_con, this, std::placeholders::_1));
+    _timer.async_wait(std::bind(&tcp_async::_clear_available_con, this,
+                                std::placeholders::_1));
   }
 
   tcp_connection::pointer new_connection =

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -114,7 +114,7 @@ void tcp_async::_clear_available_con(asio::error_code ec) {
         "{}",
         ec.message());
   else {
-    std::unique_lock<std::mutex> lck(_acceptor_con_m);
+    std::lock_guard<std::mutex> lck(_acceptor_con_m);
     std::time_t now = std::time(nullptr);
     for (auto it = _acceptor_available_con.begin();
          it != _acceptor_available_con.end();) {

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -44,7 +44,7 @@ tcp_async::~tcp_async() noexcept {
   if (_clear_available_con_running) {
     std::promise<bool> p;
     std::future<bool> f(p.get_future());
-    _stats_running = false;
+    _clear_available_con_running = false;
     asio::post(_timer.get_executor(), [this, &p] {
         _timer.cancel();
         p.set_value(true);

--- a/test/python/client-no-nego.py
+++ b/test/python/client-no-nego.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+#
+# Copyright 2020 Centreon
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For more information : contact@centreon.com
+#
+# This script is a little tcp server working on port 5669. It can simulate
+# a cbd instance. It is useful to test the validity of BBDO packets sent by
+# centengine.
+
+import socket, sys, time
+from datetime import datetime
+
+host_addr = '10.0.2.15'
+host_port = 5669
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.connect((host_addr, host_port))
+
+# Just not to close the socket immediatly
+time.sleep(30)


### PR DESCRIPTION
## Description

Sometimes, connector closes connections but acceptor keeps them. This leads to CLOSE_WAIT states. This patch fixes this issue.

REFS: MON-6393

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [X] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)
