### PR TITLE
fix(entry): bad memory allocation

### DIFF
--- a/core/inc/com/centreon/broker/mapping/entry.hh
+++ b/core/inc/com/centreon/broker/mapping/entry.hh
@@ -36,9 +36,8 @@ namespace mapping {
 class entry {
   const uint32_t _attribute;
   char const* _name_v2;
-  source* _ptr;
   const bool _serialize;
-  std::shared_ptr<source> _source;
+  source* _source;
   const source::source_type _type;
 
  public:
@@ -67,10 +66,8 @@ class entry {
       : _attribute(attr),
         _name_v2(name),
         _serialize(serialize),
-        _type(source::STRING) {
-    _source = std::make_shared<sproperty<T>>(prop, max_len);
-    _ptr = _source.get();
-  }
+        _source(new sproperty<T>(prop, max_len)),
+        _type(source::STRING) {}
 
   /**
    *  @brief Boolean constructor.
@@ -88,10 +85,8 @@ class entry {
       : _attribute(attr),
         _name_v2(name),
         _serialize(serialize),
-        _type(source::BOOL) {
-    _source = std::make_shared<property<T>>(prop);
-    _ptr = _source.get();
-  }
+        _source(new property<T>(prop)),
+        _type(source::BOOL) {}
 
   /**
    *  @brief Double constructor.
@@ -109,10 +104,8 @@ class entry {
       : _attribute(attr),
         _name_v2(name),
         _serialize(serialize),
-        _type(source::DOUBLE) {
-    _source = std::make_shared<property<T>>(prop);
-    _ptr = _source.get();
-  }
+        _source(new property<T>(prop)),
+        _type(source::DOUBLE) {}
 
   /**
    *  @brief Unsigned integer constructor.
@@ -130,10 +123,8 @@ class entry {
       : _attribute(attr),
         _name_v2(name),
         _serialize(serialize),
-        _type(source::UINT) {
-    _source = std::make_shared<property<T>>(prop);
-    _ptr = _source.get();
-  }
+        _source(new property<T>(prop)),
+        _type(source::UINT) {}
 
   /**
    *  @brief Integer constructor.
@@ -151,10 +142,8 @@ class entry {
       : _attribute(attr),
         _name_v2(name),
         _serialize(serialize),
-        _type(source::INT) {
-    _source = std::make_shared<property<T>>(prop);
-    _ptr = _source.get();
-  }
+        _source(new property<T>(prop)),
+        _type(source::INT) {}
 
   /**
    *  @brief Unsigned short constructor.
@@ -172,10 +161,8 @@ class entry {
       : _attribute(attr),
         _name_v2(name),
         _serialize(serialize),
-        _type(source::USHORT) {
-    _source = std::make_shared<property<T>>(prop);
-    _ptr = _source.get();
-  }
+        _source(new property<T>(prop)),
+        _type(source::USHORT) {}
 
   /**
    *  @brief Short constructor.
@@ -193,10 +180,8 @@ class entry {
       : _attribute(attr),
         _name_v2(name),
         _serialize(serialize),
-        _type(source::SHORT) {
-    _source = std::make_shared<property<T>>(prop);
-    _ptr = _source.get();
-  }
+        _source(new property<T>(prop)),
+        _type(source::SHORT) {}
 
   /**
    *  @brief Time constructor.
@@ -213,10 +198,8 @@ class entry {
       : _attribute(attr),
         _name_v2(name),
         _serialize(serialize),
-        _type(source::TIME) {
-    _source = std::make_shared<property<T>>(prop);
-    _ptr = _source.get();
-  }
+        _source(new property<T>(prop)),
+        _type(source::TIME) {}
 
   /**
    *  Default constructor.
@@ -224,28 +207,31 @@ class entry {
   entry()
       : _attribute(always_valid),
         _name_v2(nullptr),
-        _ptr(nullptr),
         _serialize(false),
+        _source(nullptr),
         _type(source::UNKNOWN) {}
 
-  /**
-   *  Copy constructor.
-   *
-   *  @param[in] other  Object to copy.
-   */
-  entry(entry const& other)
+  entry(const entry&) = delete;
+  entry(entry&& other)
       : _attribute(other._attribute),
         _name_v2(other._name_v2),
-        _ptr(other._ptr),
         _serialize(other._serialize),
         _source(other._source),
-        _type(other._type) {}
-  ~entry() noexcept = default;
+        _type(other._type) {
+    other._source = nullptr;
+  }
+
+  ~entry() noexcept {
+    if (_source) {
+      delete _source;
+      _source = nullptr;
+    }
+  }
   entry& operator=(entry const&) = delete;
   uint32_t get_attribute() const { return _attribute; }
-  bool get_bool(io::data const& d) const;
-  double get_double(io::data const& d) const;
-  int get_int(io::data const& d) const;
+  bool get_bool(const io::data& d) const;
+  double get_double(const io::data& d) const;
+  int get_int(const io::data& d) const;
 
   /**
    *  Get the name of this entry in version 2.x.
@@ -259,18 +245,18 @@ class entry {
    *  @return True if entry is to be serialized.
    */
   bool get_serialize() const { return _serialize; }
-  short get_short(io::data const& d) const;
-  std::string const& get_string(io::data const& d,
+  short get_short(const io::data& d) const;
+  std::string const& get_string(const io::data& d,
                                 size_t* max_len = nullptr) const;
-  timestamp const& get_time(io::data const& d) const;
+  timestamp const& get_time(const io::data& d) const;
   /**
    *  Get entry type.
    *
    *  @return Entry type.
    */
   uint32_t get_type() const { return _type; }
-  uint32_t get_uint(io::data const& d) const;
-  unsigned short get_ushort(io::data const& d) const;
+  uint32_t get_uint(const io::data& d) const;
+  unsigned short get_ushort(const io::data& d) const;
   /**
    *  Get if this entry is a null entry.
    *

--- a/core/src/mapping/entry.cc
+++ b/core/src/mapping/entry.cc
@@ -22,13 +22,6 @@
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::mapping;
 
-/**************************************
- *                                     *
- *           Public Methods            *
- *                                     *
- **************************************/
-
-
 /**
  *  Get the boolean value.
  *
@@ -37,7 +30,7 @@ using namespace com::centreon::broker::mapping;
  *  @return The boolean value.
  */
 bool entry::get_bool(io::data const& d) const {
-  return _ptr->get_bool(d);
+  return _source->get_bool(d);
 }
 
 /**
@@ -48,7 +41,7 @@ bool entry::get_bool(io::data const& d) const {
  *  @return The double value.
  */
 double entry::get_double(io::data const& d) const {
-  return _ptr->get_double(d);
+  return _source->get_double(d);
 }
 
 /**
@@ -59,7 +52,7 @@ double entry::get_double(io::data const& d) const {
  *  @return The integer value.
  */
 int entry::get_int(io::data const& d) const {
-  return _ptr->get_int(d);
+  return _source->get_int(d);
 }
 
 /**
@@ -70,7 +63,7 @@ int entry::get_int(io::data const& d) const {
  *  @return The short value.
  */
 short entry::get_short(io::data const& d) const {
-  return _ptr->get_short(d);
+  return _source->get_short(d);
 }
 
 /**
@@ -81,7 +74,7 @@ short entry::get_short(io::data const& d) const {
  *  @return The string value.
  */
 std::string const& entry::get_string(io::data const& d, size_t* max_len) const {
-  return _ptr->get_string(d, max_len);
+  return _source->get_string(d, max_len);
 }
 
 /**
@@ -92,7 +85,7 @@ std::string const& entry::get_string(io::data const& d, size_t* max_len) const {
  *  @return The time value.
  */
 timestamp const& entry::get_time(io::data const& d) const {
-  return _ptr->get_time(d);
+  return _source->get_time(d);
 }
 
 /**
@@ -103,7 +96,7 @@ timestamp const& entry::get_time(io::data const& d) const {
  *  @return The uint32_teger value.
  */
 uint32_t entry::get_uint(io::data const& d) const {
-  return _ptr->get_uint(d);
+  return _source->get_uint(d);
 }
 
 /**
@@ -114,7 +107,7 @@ uint32_t entry::get_uint(io::data const& d) const {
  *  @return The unsigned short value.
  */
 unsigned short entry::get_ushort(io::data const& d) const {
-  return _ptr->get_ushort(d);
+  return _source->get_ushort(d);
 }
 
 /**
@@ -124,7 +117,7 @@ unsigned short entry::get_ushort(io::data const& d) const {
  *  @param[in]  value New value.
  */
 void entry::set_bool(io::data& d, bool value) const {
-  _ptr->set_bool(d, value);
+  _source->set_bool(d, value);
 }
 
 /**
@@ -134,7 +127,7 @@ void entry::set_bool(io::data& d, bool value) const {
  *  @param[in]  value New value.
  */
 void entry::set_double(io::data& d, double value) const {
-  _ptr->set_double(d, value);
+  _source->set_double(d, value);
 }
 
 /**
@@ -144,7 +137,7 @@ void entry::set_double(io::data& d, double value) const {
  *  @param[in]  value New value.
  */
 void entry::set_int(io::data& d, int value) const {
-  _ptr->set_int(d, value);
+  _source->set_int(d, value);
 }
 
 /**
@@ -154,7 +147,7 @@ void entry::set_int(io::data& d, int value) const {
  *  @param[in]  value New value.
  */
 void entry::set_short(io::data& d, short value) const {
-  _ptr->set_short(d, value);
+  _source->set_short(d, value);
 }
 
 /**
@@ -164,7 +157,7 @@ void entry::set_short(io::data& d, short value) const {
  *  @param[in]  value New value.
  */
 void entry::set_string(io::data& d, std::string const& value) const {
-  _ptr->set_string(d, value);
+  _source->set_string(d, value);
 }
 
 /**
@@ -174,7 +167,7 @@ void entry::set_string(io::data& d, std::string const& value) const {
  *  @param[in]  value New value.
  */
 void entry::set_time(io::data& d, timestamp const& value) const {
-  _ptr->set_time(d, value);
+  _source->set_time(d, value);
 }
 
 /**
@@ -184,7 +177,7 @@ void entry::set_time(io::data& d, timestamp const& value) const {
  *  @param[in]  value New value.
  */
 void entry::set_uint(io::data& d, uint32_t value) const {
-  _ptr->set_uint(d, value);
+  _source->set_uint(d, value);
 }
 
 /**
@@ -194,5 +187,5 @@ void entry::set_uint(io::data& d, uint32_t value) const {
  *  @param[in]  value New value.
  */
 void entry::set_ushort(io::data& d, unsigned short value) const {
-  _ptr->set_ushort(d, value);
+  _source->set_ushort(d, value);
 }


### PR DESCRIPTION
## Description

When centengine is shutdown, we often can remark a seffault due to a bad allocation made in the bbdo manager.
This PR fixes the issue.

REFS: MON-5939

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x (master)
