### PR TITLE
fix(bbdo): memory leak on tcp::streams

### DIFF
--- a/core/src/bbdo/acceptor.cc
+++ b/core/src/bbdo/acceptor.cc
@@ -100,7 +100,12 @@ std::unique_ptr<io::stream> acceptor::open() {
       my_bbdo->set_negotiate(_negotiate, _extensions);
       my_bbdo->set_timeout(_timeout);
       my_bbdo->set_ack_limit(_ack_limit);
-      my_bbdo->negotiate(bbdo::stream::negotiate_second);
+      try {
+        my_bbdo->negotiate(bbdo::stream::negotiate_second);
+      } catch (const std::exception& e) {
+        delete my_bbdo;
+        throw;
+      }
 
       return std::unique_ptr<io::stream>(my_bbdo);
     }

--- a/core/src/bbdo/connector.cc
+++ b/core/src/bbdo/connector.cc
@@ -91,7 +91,12 @@ std::unique_ptr<io::stream> connector::_open(
     bbdo_stream->set_coarse(_coarse);
     bbdo_stream->set_negotiate(_negotiate, _extensions);
     bbdo_stream->set_timeout(_timeout);
-    bbdo_stream->negotiate(bbdo::stream::negotiate_first);
+    try {
+      bbdo_stream->negotiate(bbdo::stream::negotiate_first);
+    } catch (std::exception& e) {
+      delete bbdo_stream;
+      throw;
+    }
     bbdo_stream->set_ack_limit(_ack_limit);
   }
   return std::unique_ptr<io::stream>(bbdo_stream);


### PR DESCRIPTION
## Description

The bug concerning the factory is not fixed for now.
But no more connections are stacked.

REFS: MON-7135

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
