### PR TITLE
Mon 7021 escape string 20.04.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 20.04.14
+
+### Fixes
+
+*SQL*
+
+The string escape function could badly make its work. This is fixed now.
+
 ## 20.04.13
 
 `Release date to be defined`

--- a/core/src/misc/string.cc
+++ b/core/src/misc/string.cc
@@ -386,11 +386,15 @@ std::string string::escape(const std::string& str, size_t s) {
     ret.resize(adjust_size_utf8(ret, s));
     if (ret.size() > 1) {
       auto it = --ret.end();
-      if (*it == '\\') {
+      size_t nb{0};
+      while (it != ret.begin() && *it == '\\') {
         --it;
-        if (*it != '\\')
-          ret.resize(ret.size() - 1);
+        nb++;
       }
+      if (it == ret.begin() && *it == '\\')
+        nb++;
+      if (nb & 1)
+        ret.resize(ret.size() - 1);
     }
     return ret;
   }

--- a/core/test/misc/string.cc
+++ b/core/test/misc/string.cc
@@ -295,3 +295,21 @@ TEST(escape, complexe) {
       "oçi 还有中国人! H");
   ASSERT_EQ(string::escape(str1, 255), res1);
 }
+
+TEST(escape, quote1) {
+  std::string str("''''''''''''''''''''");
+  std::string res("\\'\\'\\'\\'\\'");
+  ASSERT_EQ(string::escape(str, 10), res);
+}
+
+TEST(escape, quote2) {
+  std::string str("\\\\\\\\\\");
+  std::string res("\\\\\\\\\\\\\\\\");
+  ASSERT_EQ(string::escape(str, 9), res);
+}
+
+TEST(escape, quote3) {
+  std::string str("\\\\\\\\\\");
+  std::string res("\\\\\\\\\\\\\\\\\\\\");
+  ASSERT_EQ(string::escape(str, 10), res);
+}


### PR DESCRIPTION
## Description

The escape string function had a bug. Here is a fix.

REFS: MON-7021

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [X] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)

