### PR TITLE
enh(storage): remove useless join in sql query

### DIFF
--- a/storage/src/conflict_manager_sql.cc
+++ b/storage/src/conflict_manager_sql.cc
@@ -155,22 +155,19 @@ void conflict_manager::_clean_tables(uint32_t instance_id) {
   // Cancellation of downtimes.
   log_v2::sql()->debug("SQL: Cancellation of downtimes (instance_id: {})",
                        instance_id);
-  query = fmt::format(
-      "UPDATE downtimes AS d INNER JOIN hosts AS h ON d.host_id=h.host_id "
-      "SET d.cancelled=1 WHERE d.actual_end_time IS NULL AND d.cancelled=0 "
-      "AND h.instance_id={}",
-      instance_id);
+  query = fmt::format("UPDATE downtimes SET cancelled=1 WHERE actual_end_time IS NULL AND cancelled=0 "
+      "AND instance_id={}", instance_id);
+
   _mysql.run_query(query, database::mysql_error::clean_downtimes, false, conn);
   _add_action(conn, actions::downtimes);
 
   // Remove comments.
   log_v2::sql()->debug("conflict_manager: remove comments (instance_id: {})",
                        instance_id);
-  query = fmt::format(
-      "UPDATE comments AS c JOIN hosts AS h ON c.host_id=h.host_id SET "
-      "c.deletion_time={} WHERE h.instance_id={} AND c.persistent=0 AND "
-      "(c.deletion_time IS NULL OR c.deletion_time=0)",
-      time(nullptr), instance_id);
+  
+  query = fmt::format("UPDATE comments SET deletion_time={} WHERE instance_id={} AND persistent=0 AND "
+      "(deletion_time IS NULL OR deletion_time=0)", time(nullptr), instance_id);
+
   _mysql.run_query(query, database::mysql_error::clean_comments, false, conn);
   _add_action(conn, actions::comments);
 


### PR DESCRIPTION
## Description
When Broker restart, it purges downtimes and comments by executing following requests :
```
"UPDATE comments AS c JOIN hosts AS h ON c.host_id=h.host_id SET c.deletion_time=1617947929 WHERE h.instance_id=3 AND c.persistent=0 AND (c.deletion_time IS NULL OR c.deletion_time=0)
UPDATE downtimes AS d INNER JOIN hosts AS h ON d.host_id=h.host_id SET d.cancelled=1 WHERE d.actual_end_timNULL AND d.cancelled=0 AND h.instance_id=3"
```
If there are thousands of downtimes and comments, this can be problematic and takes few seconds/minutes to execute. (It can happen cause some customer don’t purge those tables)
Those queries could be optimized by removing JOIN with hosts cause instance_id column exist in downtimes & comments table.
cf (https://centreon.atlassian.net/browse/MON-7026).

How to test
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

