### PR TITLE
Mon 7176 timerange parsing

### DIFF
--- a/core/inc/com/centreon/broker/misc/string.hh
+++ b/core/inc/com/centreon/broker/misc/string.hh
@@ -48,6 +48,7 @@ inline std::string& replace(std::string& str,
 }
 
 std::list<std::string> split(std::string const& str, char sep);
+std::list<fmt::string_view> split_sv(std::string const& str, char sep);
 std::string& trim(std::string& str) throw();
 std::string base64_encode(std::string const& str);
 bool is_number(const std::string& s);

--- a/core/src/misc/string.cc
+++ b/core/src/misc/string.cc
@@ -64,6 +64,25 @@ std::list<std::string> string::split(std::string const& str, char sep) {
   return retval;
 }
 
+std::list<fmt::string_view> string::split_sv(std::string const& str, char sep) {
+  std::list<fmt::string_view> retval;
+  size_t pos = 0, new_pos;
+
+  while (pos != std::string::npos) {
+    new_pos = str.find(sep, pos);
+    if (new_pos != std::string::npos) {
+      retval.emplace_back(str.data() + pos, new_pos - pos);
+      pos = new_pos + 1;
+    } else {
+      retval.emplace_back(str.data() + pos, str.size() - pos);
+      pos = new_pos;
+    }
+  }
+
+  return retval;
+}
+
+
 std::string string::base64_encode(const std::string& str) {
   static const std::string b =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/core/src/time/timerange.cc
+++ b/core/src/time/timerange.cc
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <sstream>
 #include "com/centreon/broker/misc/string.hh"
+#include "com/centreon/broker/log_v2.hh"
 
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::time;
@@ -191,47 +192,66 @@ bool timerange::to_time_t(struct tm const& midnight,
   return (true);
 }
 
-static bool _build_time_t(std::string const& time_str, uint64_t& ret) {
-  auto f = [](std::string const& str, uint64_t& data) -> bool {
-    std::istringstream iss(str);
-    return ((iss >> data) && iss.eof());
-  };
+static bool _build_time_t(const fmt::string_view& time_str, uint64_t& ret) {
+  const char* endc = time_str.data() + time_str.size();
+  const char* begin_str = time_str.data();
+  char* endptr;
+  char* endptr1;
 
-  std::size_t pos(time_str.find(':'));
-  if (pos == std::string::npos)
-    return (false);
-  uint64_t hours;
-  if (!f(time_str.substr(0, pos), hours))
-    return (false);
-  uint64_t minutes;
-  if (!f(time_str.substr(pos + 1), minutes))
-    return (false);
+  // move cursor while we meet blanks
+  while (std::isspace(*begin_str)) { begin_str++; }
+
+  uint64_t hours = strtoull(begin_str, &endptr, 10);
+  
+  if (endptr == begin_str || endptr + 2 >= endc || *endptr != ':') {
+    log_v2::core()->error("parser timeranges: error while reading hours '{}' at {}.",
+                          begin_str, endptr - begin_str);
+    return false;
+  }
+
+  uint64_t minutes = strtoull(endptr + 1, &endptr1, 10);
+
+  if (endptr1 == endptr + 1) {
+    log_v2::core()->error("parser timeranges: error while reading minutes '{}' at {}.",
+                          begin_str, endptr1 - begin_str);
+    return false;
+  }
+
+  // move cursor while we meet blanks
+  while (endptr1 < endc && std::isspace(*endptr1)) { endptr1++; }
+
+  if (endptr1 != endc) {
+    log_v2::core()->error("parser timeranges: error while reading end "
+                          "of your timerange '{}' at {}.", begin_str,
+                          endptr1 - begin_str);
+    return false;
+  }
+
   ret = hours * 3600 + minutes * 60;
-  return (true);
+  return true;
 }
 
-bool timerange::build_timeranges_from_string(std::string const& line,
+bool timerange::build_timeranges_from_string(const std::string& line,
                                              std::list<timerange>& timeranges) {
   if (line.empty())
     return true;
 
-  std::list<std::string> timeranges_str;
-  timeranges_str = misc::string::split(line, ',');
-  for (std::list<std::string>::const_iterator it(timeranges_str.begin()),
-       end(timeranges_str.end());
-       it != end; ++it) {
-    std::size_t pos(it->find('-'));
-    if (pos == std::string::npos)
-      return (false);
+  std::list<fmt::string_view> timeranges_str{misc::string::split_sv(line, ',')};
+  for (auto& t : timeranges_str) {
+    const char* ret = strchr(t.data(), '-');
+    if (ret == NULL)
+      return false;
     uint64_t start_time;
-    if (!_build_time_t(it->substr(0, pos), start_time))
-      return (false);
+    if (!_build_time_t(fmt::string_view(t.data(), ret - t.data()), start_time))
+      return false;
     uint64_t end_time;
-    if (!_build_time_t(it->substr(pos + 1), end_time))
-      return (false);
-    timeranges.push_front(timerange(start_time, end_time));
+    if (!_build_time_t(
+            fmt::string_view(ret + 1, t.size() - (ret - t.data()) - 1),
+            end_time))
+      return false;
+    timeranges.emplace_front(start_time, end_time);
   }
-  return (true);
+  return true;
 }
 
 std::string timerange::to_string() const {

--- a/core/src/time/timerange.cc
+++ b/core/src/time/timerange.cc
@@ -18,7 +18,7 @@
 
 #include "com/centreon/broker/time/timerange.hh"
 #include <cstring>
-#include <sstream>
+#include <fmt/format.h>
 #include "com/centreon/broker/misc/string.hh"
 #include "com/centreon/broker/log_v2.hh"
 
@@ -255,21 +255,14 @@ bool timerange::build_timeranges_from_string(const std::string& line,
 }
 
 std::string timerange::to_string() const {
-  std::ostringstream oss;
-  oss << (_start / 3600) << ":" << (_start % 3600) / 60 << "-" << (_end / 3600)
-      << ":" << (_end % 3600) / 60;
-  return (oss.str());
+  return fmt::format("{:02d}:{:02d}-{:02d}:{:02d}", _start / 3600,
+                     (_start % 3600) / 60, _end / 3600, (_end % 3600) / 60);
 }
 
 std::string timerange::build_string_from_timeranges(
     std::list<timerange> const& timeranges) {
-  std::ostringstream oss;
-  for (std::list<time::timerange>::const_iterator it = timeranges.begin(),
-                                                  end = timeranges.end();
-       it != end; ++it) {
-    if (!oss.str().empty())
-      oss << ",";
-    oss << it->to_string();
-  }
-  return (oss.str());
+  std::vector<std::string> v;
+  for (auto it = timeranges.rbegin(); it != timeranges.rend(); ++it)
+    v.emplace_back(it->to_string());
+  return fmt::format("{}", fmt::join(v, ", "));
 }

--- a/core/test/time/timerange.cc
+++ b/core/test/time/timerange.cc
@@ -21,14 +21,14 @@
 #include "com/centreon/broker/time/timerange.hh"
 #include "com/centreon/broker/time/timeperiod.hh"
 #include <iostream>
-  
+
 using namespace com::centreon::broker::time;
 
 
 TEST(Timerange, ParseWeirdTimerange) {
   std::unique_ptr<timeperiod> tp;
-  
-  // Here we tests weird timeranges but they should not throw 
+
+  // Here we tests weird timeranges but they should not throw
   // Timerange parser must understands theses
 
   ASSERT_NO_THROW(tp.reset(new timeperiod(2, "test", "alias",
@@ -43,14 +43,19 @@ TEST(Timerange, ParseWeirdTimerange) {
   auto& v = tp->get_timeranges();
   ASSERT_EQ(v[0].front().start(), 28800);
   ASSERT_EQ(v[0].front().end(), 43200);
+  ASSERT_EQ(v[0].front().to_string(), "08:00-12:00");
   ASSERT_EQ(v[5].front().start(), 36000);
   ASSERT_EQ(v[5].front().end(), 43200);
   ASSERT_EQ(v[5].back().start(), 28800);
   ASSERT_EQ(v[5].front().end(), 43200);
+  ASSERT_EQ(timerange::build_string_from_timeranges(v[5]),
+      "08:00-12:00, 09:00-12:00, 10:00-12:00");
   ASSERT_EQ(v[6].front().start(), 36000);
   ASSERT_EQ(v[6].front().end(), 43200);
   ASSERT_EQ(v[6].back().start(), 28800);
   ASSERT_EQ(v[6].front().end(), 43200);
+  ASSERT_EQ(timerange::build_string_from_timeranges(v[6]),
+      "08:00-12:00, 09:00-12:00, 10:00-12:00");
 
 }
 

--- a/core/test/time/timerange.cc
+++ b/core/test/time/timerange.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+#include <gtest/gtest.h>
+#include "com/centreon/broker/time/timerange.hh"
+#include "com/centreon/broker/time/timeperiod.hh"
+#include <iostream>
+  
+using namespace com::centreon::broker::time;
+
+
+TEST(Timerange, ParseWeirdTimerange) {
+  std::unique_ptr<timeperiod> tp;
+  
+  // Here we tests weird timeranges but they should not throw 
+  // Timerange parser must understands theses
+
+  ASSERT_NO_THROW(tp.reset(new timeperiod(2, "test", "alias",
+      "\r \r08:00\r-12:00\r",
+      "\n\n08:00 - 12:00\r",
+      "08:00 -12:00\r",
+      "08:00 - \n12:00\r",
+      "08:00\t-\t12:00\r",
+      "08:00-12:00,09:00-12:00,10:00-12:00",
+      "08:00-12:00 , 09:00-12:00, \r\n 10:00-12:00")));
+
+  auto& v = tp->get_timeranges();
+  ASSERT_EQ(v[0].front().start(), 28800);
+  ASSERT_EQ(v[0].front().end(), 43200);
+  ASSERT_EQ(v[5].front().start(), 36000);
+  ASSERT_EQ(v[5].front().end(), 43200);
+  ASSERT_EQ(v[5].back().start(), 28800);
+  ASSERT_EQ(v[5].front().end(), 43200);
+  ASSERT_EQ(v[6].front().start(), 36000);
+  ASSERT_EQ(v[6].front().end(), 43200);
+  ASSERT_EQ(v[6].back().start(), 28800);
+  ASSERT_EQ(v[6].front().end(), 43200);
+
+}
+
+TEST(Timerange, ParseWrongTimerange) {
+  timerange t(10, 60);
+  std::list<timerange> l;
+  ASSERT_FALSE(t.build_timeranges_from_string("08:00-12:00abc", l));
+  ASSERT_FALSE(t.build_timeranges_from_string("08:00-12:00 abc", l));
+  ASSERT_FALSE(t.build_timeranges_from_string("08:00abc-12:00", l));
+  ASSERT_FALSE(t.build_timeranges_from_string("08:00 abc-12:00", l));
+  ASSERT_FALSE(t.build_timeranges_from_string("abc08:00-12:00", l));
+  ASSERT_FALSE(t.build_timeranges_from_string("\n   abc08:00-12:00", l));
+  ASSERT_FALSE(t.build_timeranges_from_string("08abcd:00-12:00", l));
+  ASSERT_FALSE(t.build_timeranges_from_string("  :00-12:00", l));
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,12 +94,14 @@ add_executable(ut
   ${TESTS_DIR}/multiplexing/subscriber/ctor_default.cc
   ${TESTS_DIR}/processing/acceptor.cc
   ${TESTS_DIR}/processing/feeder.cc
+  ${TESTS_DIR}/time/timerange.cc
   ${TESTS_DIR}/rpc/brokerrpc.cc
   ${TESTS_DIR}/exceptions.cc
   ${TESTS_DIR}/io.cc
   ${TESTS_DIR}/logging.cc
   ${TESTS_DIR}/main.cc
   ${TESTS_DIR}/test_server.cc
+
   # Module sources.
   ${TESTS_SOURCES}
   )


### PR DESCRIPTION
## Description

Timeranges of timeperiods can't be parsed if they end with \r or \n. Now its possible.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

