### PR TITLE
Using conan center 20.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Enhancement
 
+*Build*
+
+cbd could not build anymore since the bintray closure. cbd dependencies have
+been moved to the conan-center. The build is back.
+
 *Bam*
 
 *ba worst/best states computation*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,6 @@ else ()
       LOG_BUILD ON)
 endif ()
 
-
 ExternalProject_Get_Property(json11_lib source_dir)
 ExternalProject_Get_Property(json11_lib binary_dir)
 set(json11_INCLUDE_DIRS ${source_dir})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 ##
-## Copyright 2009-2020 Centreon
+## Copyright 2009-2021 Centreon
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -50,7 +50,6 @@ set(INC_DIR "${PROJECT_SOURCE_DIR}/core/inc/com/centreon/broker")
 set(SRC_DIR "${PROJECT_SOURCE_DIR}/core/src")
 set(TEST_DIR "${PROJECT_SOURCE_DIR}/core/test")
 include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
-include(ExternalProject)
 
 add_custom_command(
   DEPENDS ${SRC_DIR}/database/table_max_size.py "${PROJECT_SOURCE_DIR}/simu/docker/installBroker.sql" "${PROJECT_SOURCE_DIR}/simu/docker/partitioning-logs.xml" "${PROJECT_SOURCE_DIR}/simu/docker/bam.sql" "${PROJECT_SOURCE_DIR}/simu/docker/createTablesCentstorage.sql"
@@ -99,9 +98,8 @@ set(PROTOBUF_PREFIX "${protobuf_LIB_DIRS}/..")
 message(STATUS "${PROTOBUF_PREFIX}/bin/protoc")
 set(GRPC_PREFIX "${gRPC_LIB_DIRS}/..")
 
-option(BUILD_OFFLINE "Build offline" OFF)
-
 include(ExternalProject)
+option(BUILD_OFFLINE "Build offline" OFF)
 
 if (${BUILD_OFFLINE})
   ExternalProject_Add(json11_lib
@@ -124,10 +122,10 @@ endif ()
 
 ExternalProject_Get_Property(json11_lib source_dir)
 ExternalProject_Get_Property(json11_lib binary_dir)
-
-link_directories(${binary_dir})
-include_directories(${source_dir})
-
+set(json11_INCLUDE_DIRS ${source_dir})
+set(json11_LIBS ${binary_dir})
+link_directories(${json11_LIBS})
+include_directories(${json11_INCLUDE_DIRS})
 
 add_custom_command(
   DEPENDS ${SRC_DIR}/broker.proto
@@ -615,10 +613,12 @@ add_library(roker STATIC
   ${SRC_DIR}/config/applier/init.cc
   ${SRC_DIR}/config/applier/logger.cc)
 target_link_libraries(roker rokerbase dl ${c-ares_LIBS} ${OpenSSL_LIBS} ${gRPC_LIBS} ${absl_LIBS} grpc++_reflection pthread)
+add_dependencies(roker json11_lib)
 
 # Standalone binary.
 set(DAEMON cbd)
 add_executable(${DAEMON} ${SRC_DIR}/main.cc)
+add_dependencies(${DAEMON} json11_lib)
 
 #Flags needed to include all symbols in binary.
 target_link_libraries("${DAEMON}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID STREQ
   message(FATAL_ERROR "You can build broker with g++ or clang++. CMake will exit.")
 endif ()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 add_definitions("-D_GLIBCXX_USE_CXX11_ABI=1")
 
 # With ASIO DEBUGGING ENABLED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(INC_DIR "${PROJECT_SOURCE_DIR}/core/inc/com/centreon/broker")
 set(SRC_DIR "${PROJECT_SOURCE_DIR}/core/src")
 set(TEST_DIR "${PROJECT_SOURCE_DIR}/core/test")
 include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
+include(ExternalProject)
 
 add_custom_command(
   DEPENDS ${SRC_DIR}/database/table_max_size.py "${PROJECT_SOURCE_DIR}/simu/docker/installBroker.sql" "${PROJECT_SOURCE_DIR}/simu/docker/partitioning-logs.xml" "${PROJECT_SOURCE_DIR}/simu/docker/bam.sql" "${PROJECT_SOURCE_DIR}/simu/docker/createTablesCentstorage.sql"
@@ -64,12 +65,10 @@ add_custom_target(table_max_size DEPENDS ${INC_DIR}/database/table_max_size.hh)
 set_source_files_properties(${INC_DIR}/database/table_max_size.hh PROPERTIES GENERATED TRUE)
 
 set(protobuf_MODULE_COMPATIBLE True)
-find_package(json11 REQUIRED)
 find_package(fmt REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(asio REQUIRED)
-find_package(protobuf REQUIRED)
-find_package(protoc_installer REQUIRED)
+find_package(Protobuf REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(c-ares REQUIRED)
@@ -78,16 +77,15 @@ find_package(mariadb-connector-c REQUIRED)
 
 add_definitions(${spdlog_DEFINITIONS} ${mariadb-connector-c_DEFINITIONS})
 
-include_directories(${json11_INCLUDE_DIRS})
 include_directories(${fmt_INCLUDE_DIRS})
 include_directories(${spdlog_INCLUDE_DIRS})
 include_directories(${asio_INCLUDE_DIRS})
 include_directories(${protobuf_INCLUDE_DIRS})
+include_directories(${absl_INCLUDE_DIRS})
 include_directories(${gRPC_INCLUDE_DIRS})
 include_directories(${ZLIB_INCLUDE_DIRS})
-include_directories(${mariadb-connector-c_INCLUDE_DIRS}/mysql)
+include_directories(${mariadb-connector-c_INCLUDE_DIRS})
 
-link_directories(${json11_LIB_DIRS})
 link_directories(${fmt_LIB_DIRS})
 link_directories(${spdlog_LIB_DIRS})
 link_directories(${protobuf_LIB_DIRS})
@@ -97,10 +95,39 @@ link_directories(${OpenSSL_LIB_DIRS})
 link_directories(${ZLIB_LIB_DIRS})
 link_directories(${mariadb-connector-c_LIB_DIRS})
 
-message(STATUS "Using protobuf ${gRPC_VERSION}")
-set(PROTOBUF_PREFIX "${protoc_installer_LIB_DIRS}/..")
+set(PROTOBUF_PREFIX "${protobuf_LIB_DIRS}/..")
 message(STATUS "${PROTOBUF_PREFIX}/bin/protoc")
 set(GRPC_PREFIX "${gRPC_LIB_DIRS}/..")
+
+option(BUILD_OFFLINE "Build offline" OFF)
+
+include(ExternalProject)
+
+if (${BUILD_OFFLINE})
+  ExternalProject_Add(json11_lib
+      SOURCE_DIR ${CMAKE_BINARY_DIR}/json11_lib-prefix/src/json11_lib
+      TIMEOUT 10
+      INSTALL_COMMAND ""
+      LOG_DOWNLOAD ON
+      LOG_CONFIGURE ON
+      LOG_BUILD ON)
+else ()
+  ExternalProject_Add(json11_lib
+      GIT_REPOSITORY https://github.com/dropbox/json11/
+      TIMEOUT 10
+      INSTALL_COMMAND ""
+      LOG_DOWNLOAD ON
+      LOG_CONFIGURE ON
+      LOG_BUILD ON)
+endif ()
+
+
+ExternalProject_Get_Property(json11_lib source_dir)
+ExternalProject_Get_Property(json11_lib binary_dir)
+
+link_directories(${binary_dir})
+include_directories(${source_dir})
+
 
 add_custom_command(
   DEPENDS ${SRC_DIR}/broker.proto
@@ -580,13 +607,14 @@ set(LIBROKER_SOURCES
 
 # Static libraries.
 add_library(rokerbase STATIC ${LIBROKER_SOURCES})
+add_dependencies(rokerbase json11_lib)
 set_target_properties(rokerbase PROPERTIES COMPILE_FLAGS "-fPIC")
-target_link_libraries(rokerbase ${ZLIB_LIBRARIES} ${mariadb-connector-c_LIBS} pthread dl berpc)
+target_link_libraries(rokerbase json11 ${ZLIB_LIBRARIES} ${OpenSSL_LIBS} ${mariadb-connector-c_LIBS} pthread dl berpc)
 
 add_library(roker STATIC
   ${SRC_DIR}/config/applier/init.cc
   ${SRC_DIR}/config/applier/logger.cc)
-target_link_libraries(roker rokerbase dl ${c-ares_LIBS} ${gRPC_LIBS} ${absl_LIBS} grpc++_reflection)
+target_link_libraries(roker rokerbase dl ${c-ares_LIBS} ${OpenSSL_LIBS} ${gRPC_LIBS} ${absl_LIBS} grpc++_reflection pthread)
 
 # Standalone binary.
 set(DAEMON cbd)
@@ -594,10 +622,10 @@ add_executable(${DAEMON} ${SRC_DIR}/main.cc)
 
 #Flags needed to include all symbols in binary.
 target_link_libraries("${DAEMON}"
-	"-Wl,--whole-archive" grpc++_reflection rokerbase roker "-Wl,--no-whole-archive" ${json11_LIBS} ${fmt_LIBS} ${spdlog_LIBS} ${gRPC_LIBS} ${absl_LIBS} )
+	"-Wl,--whole-archive" grpc++_reflection rokerbase roker "-Wl,--no-whole-archive" json11 ${fmt_LIBS} ${spdlog_LIBS} ${gRPC_LIBS} ${absl_LIBS} )
 
 # Centreon Broker Watchdog
-option(WITH_CBWD "Build centreon broker watchdong." ON)
+option(WITH_CBWD "Build centreon broker watchdog." ON)
 if (WITH_CBWD)
   add_subdirectory(watchdog)
 endif ()

--- a/bam/CMakeLists.txt
+++ b/bam/CMakeLists.txt
@@ -199,6 +199,8 @@ if (WITH_TESTING )
     )
 endif (WITH_TESTING)
 
+add_dependencies("${BAM}" json11_lib)
+
 # Install rule.
 install(TARGETS "${BAM}"
   LIBRARY DESTINATION "${PREFIX_MODULES}"

--- a/cmake.sh
+++ b/cmake.sh
@@ -9,6 +9,7 @@ This program build Centreon-broker
     -h|--help     : help
 EOF
 }
+
 BUILD_TYPE="Debug"
 for i in "$@"
 do
@@ -75,20 +76,28 @@ if [ -r /etc/centos-release ] ; then
     curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/rpms/MariaDB-common-10.5.8-1.el7.centos.x86_64.rpm --output MariaDB-common-10.5.8-1.el7.centos.x86_64.rpm
     curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/rpms/MariaDB-compat-10.5.8-1.el7.centos.x86_64.rpm --output MariaDB-compat-10.5.8-1.el7.centos.x86_64.rpm
     yum install -y MariaDB*.rpm
+    pkgs=(
+      devtool-9
+      ninja-build
+      rrdtool-devel
+      gnutls-devel
+      lua-devel
+      perl-Thread-Queue
+    )
   else
     curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos8-amd64/rpms/MariaDB-shared-10.5.8-1.el8.x86_64.rpm --output MariaDB-shared-10.5.8-1.el8.x86_64.rpm
     curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos8-amd64/rpms/MariaDB-common-10.5.8-1.el8.x86_64.rpm --output MariaDB-common-10.5.8-1.el8.x86_64.rpm
     curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos8-amd64/rpms/MariaDB-compat-10.5.8-1.el8.x86_64.rpm --output MariaDB-compat-10.5.8-1.el8.x86_64.rpm
     dnf install -y MariaDB-*.rpm
+    pkgs=(
+      ninja-build
+      rrdtool-devel
+      gnutls-devel
+      lua-devel
+      perl-Thread-Queue
+    )
   fi
 
-  pkgs=(
-    ninja-build
-    rrdtool-devel
-    gnutls-devel
-    lua-devel
-    perl-Thread-Queue
-  )
   for i in "${pkgs[@]}"; do
     if ! rpm -q $i ; then
       if [ $maj = 'centos7' ] ; then
@@ -206,9 +215,6 @@ if [ $my_id -eq 0 ] ; then
 else
   conan="$HOME/.local/bin/conan"
 fi
-
-
-
 
 if [ ! -d build ] ; then
   mkdir build

--- a/cmake.sh
+++ b/cmake.sh
@@ -3,9 +3,7 @@
 show_help() {
 cat << EOF
 Usage: ${0##*/} -n=[yes|no] -v
-
 This program build Centreon-broker
-
     -f|--force    : force rebuild
     -r|--release  : Build on release mode
     -h|--help     : help
@@ -62,8 +60,26 @@ if [ -r /etc/centos-release ] ; then
     echo "pip3 already installed"
   fi
 
-  if ! rpm -q gcc-c++ ; then
-    yum -y install gcc-c++
+  good=$(gcc --version | awk '/gcc/ && ($3+0)>5.0{print 1}')
+
+  if [ ! $good ] ; then
+    yum -y install centos-release-scl
+    yum-config-manager --enable rhel-server-rhscl-7-rpms
+    yum -y install devtoolset-9
+    ln -s /usr/bin/cmake3 /usr/bin/cmake
+    source /opt/rh/devtoolset-9/enable
+  fi
+
+  if [ $maj = "centos7" ] ; then
+    curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/rpms/MariaDB-shared-10.5.8-1.el7.centos.x86_64.rpm --output MariaDB-shared-10.5.8-1.el7.centos.x86_64.rpm
+    curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/rpms/MariaDB-common-10.5.8-1.el7.centos.x86_64.rpm --output MariaDB-common-10.5.8-1.el7.centos.x86_64.rpm
+    curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/rpms/MariaDB-compat-10.5.8-1.el7.centos.x86_64.rpm --output MariaDB-compat-10.5.8-1.el7.centos.x86_64.rpm
+    yum install -y MariaDB*.rpm
+  else
+    curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos8-amd64/rpms/MariaDB-shared-10.5.8-1.el8.x86_64.rpm --output MariaDB-shared-10.5.8-1.el8.x86_64.rpm
+    curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos8-amd64/rpms/MariaDB-common-10.5.8-1.el8.x86_64.rpm --output MariaDB-common-10.5.8-1.el8.x86_64.rpm
+    curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos8-amd64/rpms/MariaDB-compat-10.5.8-1.el8.x86_64.rpm --output MariaDB-compat-10.5.8-1.el8.x86_64.rpm
+    dnf install -y MariaDB-*.rpm
   fi
 
   pkgs=(
@@ -71,6 +87,7 @@ if [ -r /etc/centos-release ] ; then
     rrdtool-devel
     gnutls-devel
     lua-devel
+    perl-Thread-Queue
   )
   for i in "${pkgs[@]}"; do
     if ! rpm -q $i ; then
@@ -83,11 +100,17 @@ if [ -r /etc/centos-release ] ; then
   done
 elif [ -r /etc/issue ] ; then
   maj=$(cat /etc/issue | awk '{print $1}')
+  version=$(cat /etc/issue | awk '{print $3}')
+  if [ $version = "9" ] ; then
+    dpkg="dpkg"
+  else
+    dpkg="dpkg --no-pager"
+  fi
   v=$(cmake --version)
   if [[ $v =~ "version 3" ]] ; then
     cmake='cmake'
   elif [ $maj = "Debian" ] ; then
-    if dpkg -l --no-pager cmake ; then
+    if $dpkg -l cmake ; then
       echo "Bad version of cmake..."
       exit 1
     else
@@ -130,7 +153,6 @@ elif [ -r /etc/issue ] ; then
         fi
       fi
     done
-  fi
   elif [ $maj = "Raspbian" ] ; then
     pkgs=(
       gcc
@@ -165,7 +187,7 @@ elif [ -r /etc/issue ] ; then
   else
     echo "python3 already installed"
   fi
-  if ! dpkg -l --no-pager python3-pip ; then
+  if ! $dpkg -l python3-pip ; then
     if [ $my_id -eq 0 ] ; then
       apt install -y python3-pip
     else
@@ -175,7 +197,7 @@ elif [ -r /etc/issue ] ; then
   else
     echo "pip3 already installed"
   fi
-
+fi
 
 pip3 install conan --upgrade
 
@@ -184,11 +206,9 @@ if [ $my_id -eq 0 ] ; then
 else
   conan="$HOME/.local/bin/conan"
 fi
-if ! $conan remote list | grep ^centreon ; then
-  $conan remote add centreon https://api.bintray.com/conan/centreon/centreon
-fi
 
-good=$(gcc --version | awk '/gcc/ && ($3+0)>5.0{print 1}')
+
+
 
 if [ ! -d build ] ; then
   mkdir build
@@ -201,17 +221,17 @@ if [ "$force" = "1" ] ; then
   mkdir build
 fi
 cd build
-
-if [ $good -eq 1 ] ; then
-  $conan install .. --remote centreon -s compiler.libcxx=libstdc++11
+if [ $maj = "centos7" ] ; then
+    rm -rf ~/.conan/profiles/default
+    $conan install .. -s compiler.libcxx=libstdc++11 --build=missing
 else
-  $conan install .. --remote centreon -s compiler.libcxx=libstdc++
+    $conan install .. -s compiler.libcxx=libstdc++11 --build=missing
 fi
 
 if [ $maj = "Raspbian" ] ; then
-  CXXFLAGS="-Wall -Wextra" $cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-broker -DWITH_GROUP=centreon-broker -DWITH_CONFIG_PREFIX=/etc/centreon-broker -DWITH_TESTING=On -DWITH_PREFIX_MODULES=/usr/share/centreon/lib/centreon-broker -DWITH_PREFIX_CONF=/etc/centreon-broker -DWITH_PREFIX_LIB=/usr/lib64/nagios -DWITH_MODULE_SIMU=On -DUSE_CXX11_ABI=1 $* ..
+  CXXFLAGS="-Wall -Wextra" $cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-broker -DWITH_GROUP=centreon-broker -DWITH_CONFIG_PREFIX=/etc/centreon-broker -DWITH_TESTING=On -DWITH_PREFIX_MODULES=/usr/share/centreon/lib/centreon-broker -DWITH_PREFIX_CONF=/etc/centreon-broker -DWITH_PREFIX_LIB=/usr/lib64/nagios -DWITH_MODULE_SIMU=On $* ..
 elif [ $maj = "Debian" ] ; then
-  CXXFLAGS="-Wall -Wextra" $cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-broker -DWITH_GROUP=centreon-broker -DWITH_CONFIG_PREFIX=/etc/centreon-broker -DWITH_TESTING=On -DWITH_PREFIX_MODULES=/usr/share/centreon/lib/centreon-broker -DWITH_PREFIX_CONF=/etc/centreon-broker -DWITH_PREFIX_LIB=/usr/lib64/nagios -DWITH_MODULE_SIMU=On -DUSE_CXX11_ABI=1 $* ..
+  CXXFLAGS="-Wall -Wextra" $cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-broker -DWITH_GROUP=centreon-broker -DWITH_CONFIG_PREFIX=/etc/centreon-broker -DWITH_TESTING=On -DWITH_PREFIX_MODULES=/usr/share/centreon/lib/centreon-broker -DWITH_PREFIX_CONF=/etc/centreon-broker -DWITH_PREFIX_LIB=/usr/lib64/nagios -DWITH_MODULE_SIMU=On $* ..
 else
-  CXXFLAGS="-Wall -Wextra" $cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-broker -DWITH_GROUP=centreon-broker -DWITH_CONFIG_PREFIX=/etc/centreon-broker -DWITH_TESTING=On -DWITH_PREFIX_MODULES=/usr/share/centreon/lib/centreon-broker -DWITH_PREFIX_CONF=/etc/centreon-broker -DWITH_PREFIX_LIB=/usr/lib64/nagios -DWITH_MODULE_SIMU=On -DUSE_CXX11_ABI=0 $* ..
+  CXXFLAGS="-Wall -Wextra" $cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-broker -DWITH_GROUP=centreon-broker -DWITH_CONFIG_PREFIX=/etc/centreon-broker -DWITH_TESTING=On -DWITH_PREFIX_MODULES=/usr/share/centreon/lib/centreon-broker -DWITH_PREFIX_CONF=/etc/centreon-broker -DWITH_PREFIX_LIB=/usr/lib64/nagios -DWITH_MODULE_SIMU=On $* ..
 fi

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,14 +1,14 @@
 [requires]
-gtest/1.8.1@bincrafters/stable
-asio/1.18.0
-fmt/7.1.2
-spdlog/1.8.1
-json11/e2e3a11@centreon/stable
-openssl/1.1.1h
-grpc/1.27.3@inexorgame/stable
-mariadb-connector-c/3.1.10
-zlib/1.2.11
+gtest/cci.20210126
+asio/1.18.1
+fmt/7.1.3
+spdlog/1.8.5
+openssl/1.1.1k
+protobuf/3.15.5
+grpc/1.37.0
+mariadb-connector-c/3.1.12
 
+zlib/1.2.11
 [generators]
 cmake_paths
 cmake_find_package

--- a/correlation/CMakeLists.txt
+++ b/correlation/CMakeLists.txt
@@ -31,6 +31,7 @@ unset(QT_WRAPPED_SOURCES)
 # Correlation module.
 set(CORRELATION "30-correlation")
 set(CORRELATION "${CORRELATION}" PARENT_SCOPE)
+
 add_library("${CORRELATION}" SHARED
   # Sources.
   "${SRC_DIR}/connector.cc"
@@ -58,6 +59,7 @@ add_library("${CORRELATION}" SHARED
   # Qt-processed files.
   ${QT_WRAPPED_SOURCES}
 )
+add_dependencies("${CORRELATION}" json11_lib)
 
 set_target_properties(${CORRELATION} PROPERTIES PREFIX "")
 

--- a/graphite/CMakeLists.txt
+++ b/graphite/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library("${GRAPHITE}" SHARED
   "${INC_DIR}/query.hh"
   "${INC_DIR}/macro_cache.hh"
 )
+add_dependencies("${GRAPHITE}" json11_lib)
 set_target_properties("${GRAPHITE}" PROPERTIES PREFIX "")
 
 # Testing.

--- a/influxdb/CMakeLists.txt
+++ b/influxdb/CMakeLists.txt
@@ -48,6 +48,8 @@ add_library("${INFLUXDB}" SHARED
   "${INC_DIR}/macro_cache.hh"
   "${INC_DIR}/stream.hh"
 )
+add_dependencies("${INFLUXDB}" json11_lib)
+
 set_target_properties("${INFLUXDB}" PROPERTIES PREFIX "")
 
 # Testing.

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library("${LUA}" SHARED
   "${INC_DIR}/macro_cache.hh"
   "${INC_DIR}/stream.hh"
 )
+add_dependencies("${LUA}" json11_lib)
 target_link_libraries("${LUA}" ${LUA_LIBRARIES})
 set_target_properties("${LUA}" PROPERTIES PREFIX "")
 

--- a/neb/CMakeLists.txt
+++ b/neb/CMakeLists.txt
@@ -98,7 +98,7 @@ set(NEB_SOURCES
 
 # Static library.
 add_library(nebbase STATIC ${NEB_SOURCES})
-add_dependencies(nebbase table_max_size)
+add_dependencies(nebbase table_max_size json11_lib)
 set(NEBBASE_CXXFLAGS "${NEBBASE_CXXFLAGS} -fPIC")
 set_property(TARGET nebbase PROPERTY COMPILE_FLAGS ${NEBBASE_CXXFLAGS})
 
@@ -225,9 +225,9 @@ set_property(TARGET "${CBMOD}"
 if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # Flags needed to include all symbols in shared library.
   target_link_libraries("${CBMOD}"
-    "-Wl,--whole-archive" "nebbase" "rokerbase" "-Wl,--no-whole-archive" ${json11_LIBS} ${fmt_LIBS} ${spdlog_LIBS} ${asio_LIBS})
+    "-Wl,--whole-archive" "nebbase" "rokerbase" "-Wl,--no-whole-archive" ${fmt_LIBS} ${spdlog_LIBS} ${asio_LIBS})
 else ()
-  target_link_libraries("${CBMOD}" "nebbase" "rokerbase" ${json11_LIBS} ${fmt_LIBS} ${spdlog_LIBS} ${asio_LIBS})
+  target_link_libraries("${CBMOD}" "nebbase" "rokerbase" ${fmt_LIBS} ${spdlog_LIBS} ${asio_LIBS})
 endif ()
 set_target_properties("${CBMOD}" PROPERTIES PREFIX "")
 

--- a/rrd/CMakeLists.txt
+++ b/rrd/CMakeLists.txt
@@ -72,6 +72,8 @@ add_library("${RRD}" SHARED
   "${INC_DIR}/com/centreon/broker/rrd/lib.hh"
   "${INC_DIR}/com/centreon/broker/rrd/output.hh"
   )
+add_dependencies("${RRD}" json11_lib)
+
 set_target_properties("${RRD}" PROPERTIES PREFIX "")
 
 # Compile with librrd flags.

--- a/simu/CMakeLists.txt
+++ b/simu/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library("${SIMU}" SHARED
   "${INC_DIR}/luabinding.hh"
   "${INC_DIR}/stream.hh"
 )
+add_dependencies("${SIMU}" json11_lib)
 target_link_libraries("${SIMU}" ${LUA_LIBRARIES})
 set_target_properties("${SIMU}" PROPERTIES PREFIX "")
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library("${SQL}" SHARED
   "${INC_DIR}/com/centreon/broker/sql/factory.hh"
   "${INC_DIR}/com/centreon/broker/sql/stream.hh"
 )
-
+add_dependencies("${SQL}" json11_lib)
 set_target_properties("${SQL}" PROPERTIES
     PREFIX ""
     COMPILE_FLAGS "-fPIC")

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -43,6 +43,8 @@ add_library("${STATS}" SHARED
 set_target_properties("${STATS}" PROPERTIES
     PREFIX "")
 
+add_dependencies("${STATS}" json11_lib)
+
 # Testing.
 if (WITH_TESTING)
   set(

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -41,6 +41,8 @@ set(CONFLICTMGR "conflictmgr" PARENT_SCOPE)
 set_target_properties(conflictmgr PROPERTIES
     COMPILE_FLAGS "-fPIC")
 
+add_dependencies(conflictmgr json11_lib)
+
 # Storage module.
 set(STORAGE "20-storage")
 set(STORAGE "${STORAGE}" PARENT_SCOPE)
@@ -77,6 +79,7 @@ add_library("${STORAGE}" SHARED
   "${INC_DIR}/status.hh"
   "${INC_DIR}/stream.hh"
 )
+add_dependencies("${STORAGE}" json11_lib)
 set_target_properties("${STORAGE}" PROPERTIES
     PREFIX ""
     COMPILE_FLAGS "-fPIC")

--- a/tcp/CMakeLists.txt
+++ b/tcp/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library("${TCP}" SHARED
   ${SOURCES}
   ${HEADERS}
 )
+add_dependencies("${TCP}" json11_lib)
 set_target_properties("${TCP}" PROPERTIES PREFIX "")
 
 # Testing.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@
 ## For more information : contact@centreon.com
 ##
 
-find_package(gtest REQUIRED)
+find_package(GTest REQUIRED)
 include_directories(${gtest_INCLUDE_DIRS})
 link_directories(${gtest_LIB_DIRS})
 
@@ -107,8 +107,8 @@ add_executable(ut
 
 #set_target_properties("ut" PROPERTIES COMPILE_FLAGS "${MYSQL_CFLAGS}")
 
-target_link_libraries(ut rokerbase roker ${TESTS_LIBRARIES} conflictmgr
-	${json11_LIBS} ${asio_LIBS} ${fmt_LIBS} ${spdlog_LIBS} ${gtest_LIBS} ${mariadb-connector-c_LIBS} ${OpenSSL_LIBS} ${gRPC_LIBS} ${absl_LIBS} )
+target_link_libraries(ut rokerbase roker ${TESTS_LIBRARIES} conflictmgr 
+  ${asio_LIBS} ${fmt_LIBS} ${spdlog_LIBS} ${GTest_LIBS} ${mariadb-connector-c_LIBS} ${OpenSSL_LIBS} ${gRPC_LIBS} ${absl_LIBS} )
 
 add_test(NAME tests COMMAND ut)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,8 +17,8 @@
 ##
 
 find_package(GTest REQUIRED)
-include_directories(${gtest_INCLUDE_DIRS})
-link_directories(${gtest_LIB_DIRS})
+include_directories(${GTest_INCLUDE_DIRS})
+link_directories(${GTest_LIB_DIRS})
 
 # Tests directory.
 set(TESTS_DIR ${PROJECT_SOURCE_DIR}/core/test)
@@ -56,7 +56,7 @@ endif (WITH_SQL_TESTS)
 add_definitions(-DBROKERRPC_TESTS_PATH="${TESTS_DIR}/rpc")
 
 add_executable(rpc_client ${TESTS_DIR}/rpc/client.cc)
-target_link_libraries(rpc_client berpc ${gRPC_LIBS} ${absl_LIBS} ${OpenSSL_LIBS} ${c-ares_LIBS} ${ZLIB_LIBS} dl)
+target_link_libraries(rpc_client berpc ${gRPC_LIBS} ${absl_LIBS} ${OpenSSL_LIBS} ${c-ares_LIBS} ${ZLIB_LIBS} dl pthread)
 
 add_executable(ut
   # Core sources.

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -61,7 +61,7 @@ add_library("${TLS}" SHARED
   "${INC_DIR}/params.hh"
   "${INC_DIR}/stream.hh"
 )
-
+add_dependencies("${TLS}" json11_lib)
 target_link_libraries("${TLS}" ${GNUTLS_LIBRARIES})
 
 set_target_properties("${TLS}" PROPERTIES PREFIX "")

--- a/watchdog/CMakeLists.txt
+++ b/watchdog/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SRC_DIR "${PROJECT_SOURCE_DIR}/watchdog/src")
 set(TEST_DIR "${PROJECT_SOURCE_DIR}/watchdog/test")
 include_directories(${PROJECT_SOURCE_DIR}/watchdog/inc/
                     ${PROJECT_SOURCE_DIR}/neb/inc/
+                    ${json11_INCLUDE_DIRS}
 )
 
 # Watchdog binary.
@@ -40,8 +41,9 @@ add_executable("${WATCHDOG}"
   ${INC_DIR}/instance.hh
   ${INC_DIR}/instance_configuration.hh
 )
+add_dependencies("${WATCHDOG}" json11_lib)
 
-target_link_libraries(${WATCHDOG} pthread ${fmt_LIBS} ${spdlog_LIBS})
+target_link_libraries(${WATCHDOG} pthread ${fmt_LIBS} ${spdlog_LIBS} json11)
 
 if (WITH_WATCHDOG_TESTS)
   # Testing.

--- a/watchdog/CMakeLists.txt
+++ b/watchdog/CMakeLists.txt
@@ -41,7 +41,7 @@ add_executable("${WATCHDOG}"
   ${INC_DIR}/instance_configuration.hh
 )
 
-target_link_libraries(${WATCHDOG} pthread ${fmt_LIBS} ${spdlog_LIBS} ${json11_LIBS})
+target_link_libraries(${WATCHDOG} pthread ${fmt_LIBS} ${spdlog_LIBS})
 
 if (WITH_WATCHDOG_TESTS)
   # Testing.


### PR DESCRIPTION
## Description

Broker 20.10 can be compiled now using conan-center packages.
On centos7, we need devtoolset-9.

REFS: MON-7244

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [X] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)
