### PR TITLE
Mon 7398 tls query 20.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixes
 
+TLS*
+
+GnuTLS query was not understood on RedHat 8 and Centos8.
+
 *Timeranges*
 
 Allowing parser \r or \n for the parser of timeranges.

--- a/tls/src/params.cc
+++ b/tls/src/params.cc
@@ -58,14 +58,8 @@ void params::apply(gnutls_session_t session) {
   ret = gnutls_priority_set_direct(
       session,
       (_compress
-           ? "NORMAL:-CIPHER-ALL:+AES-256-CBC:+AES-128-CBC:+AES-128-GCM:+AES-"
-             "256-GCM:+AES-128-PGP-CFB:+AES-256-PGP-CFB:-VERS-DTLS1.0:-"
-             "VERS-DTLS1.2:-VERS-SSL3.0:-"
-             "VERS-TLS1.0:-VERS-TLS1.1:+ANON-DH:%COMPAT"
-           : "NORMAL:-CIPHER-ALL:+AES-256-CBC:+AES-128-CBC:+AES-128-GCM:+AES-"
-             "256-GCM:+AES-128-PGP-CFB:+AES-256-PGP-CFB:-VERS-DTLS1.0:-"
-             "VERS-DTLS1.2:-VERS-SSL3.0:-"
-             "VERS-TLS1.0:-VERS-TLS1.1:+ANON-DH:+COMP-"
+           ? "NORMAL:-VERS-DTLS1.0:-VERS-DTLS1.2:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:+ANON-DH:%COMPAT"
+           : "NORMAL:-VERS-DTLS1.0:-VERS-DTLS1.2:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:+ANON-DH:+COMP-"
              "DEFLATE:%COMPAT"),
       nullptr);
 

--- a/tls/src/params.cc
+++ b/tls/src/params.cc
@@ -57,10 +57,11 @@ void params::apply(gnutls_session_t session) {
   int ret;
   ret = gnutls_priority_set_direct(
       session,
-      (_compress
-           ? "NORMAL:-VERS-DTLS1.0:-VERS-DTLS1.2:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:+ANON-DH:%COMPAT"
-           : "NORMAL:-VERS-DTLS1.0:-VERS-DTLS1.2:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:+ANON-DH:+COMP-"
-             "DEFLATE:%COMPAT"),
+      (_compress ? "NORMAL:-VERS-DTLS1.0:-VERS-DTLS1.2:-VERS-SSL3.0:-VERS-TLS1."
+                   "0:-VERS-TLS1.1:+ANON-DH:%COMPAT"
+                 : "NORMAL:-VERS-DTLS1.0:-VERS-DTLS1.2:-VERS-SSL3.0:-VERS-TLS1."
+                   "0:-VERS-TLS1.1:+ANON-DH:+COMP-"
+                   "DEFLATE:%COMPAT"),
       nullptr);
 
   if (ret != GNUTLS_E_SUCCESS) {


### PR DESCRIPTION
## Description

TLS query was not understood on Centos8/Redhat 8

REFS: MON-7398

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)
