### PR TITLE
Mon 7373 engine reco 21.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Converts theses events into trace.
 Connections can fail when many pollers establish connection to cbd. This should
 be fixed with this new version.
 
+When cbd is stopped, sometimes centengine cannot reconnect. This is fixed now.
+
 ### Enhancements
 
 *Timeranges*


### PR DESCRIPTION
## Description

when cbd is restarted, centengine can enter in an infinite loop instead of trying to reconnect.

REFS: MON-7373

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x
- [ ] 21.10.x (master)
