### PR TITLE
fix(tcp): getting remote endpoint from a socket may fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ GnuTLS query was not understood on RedHat 8 and Centos8.
 
 Converts theses events into trace.
 
-*tcp*
+*TCP*
 
 Connections can fail when many pollers establish connection to cbd. This should
 be fixed with this new version.
+
+The calls to get remote endpoints from a socket were not protected and could
+fail ; this made cbd/centengine to stop.
 
 ### Build
 

--- a/core/inc/com/centreon/broker/log_v2.hh
+++ b/core/inc/com/centreon/broker/log_v2.hh
@@ -30,16 +30,17 @@ CCB_BEGIN()
 
 class log_v2 {
   std::string _log_name;
-  std::shared_ptr<spdlog::logger> _core_log;
-  std::shared_ptr<spdlog::logger> _config_log;
-  std::shared_ptr<spdlog::logger> _tcp_log;
-  std::shared_ptr<spdlog::logger> _bbdo_log;
-  std::shared_ptr<spdlog::logger> _tls_log;
-  std::shared_ptr<spdlog::logger> _sql_log;
-  std::shared_ptr<spdlog::logger> _perfdata_log;
-  std::shared_ptr<spdlog::logger> _lua_log;
-  std::shared_ptr<spdlog::logger> _processing_log;
   std::shared_ptr<spdlog::logger> _bam_log;
+  std::shared_ptr<spdlog::logger> _bbdo_log;
+  std::shared_ptr<spdlog::logger> _config_log;
+  std::shared_ptr<spdlog::logger> _core_log;
+  std::shared_ptr<spdlog::logger> _influxdb_log;
+  std::shared_ptr<spdlog::logger> _lua_log;
+  std::shared_ptr<spdlog::logger> _perfdata_log;
+  std::shared_ptr<spdlog::logger> _processing_log;
+  std::shared_ptr<spdlog::logger> _sql_log;
+  std::shared_ptr<spdlog::logger> _tcp_log;
+  std::shared_ptr<spdlog::logger> _tls_log;
   std::mutex _load_m;
 
   log_v2();
@@ -50,16 +51,17 @@ class log_v2 {
   bool load(const char* file, std::string const& broker_name, std::string& err);
   const std::string& log_name() const;
 
-  static std::shared_ptr<spdlog::logger> core();
-  static std::shared_ptr<spdlog::logger> config();
-  static std::shared_ptr<spdlog::logger> tls();
-  static std::shared_ptr<spdlog::logger> bbdo();
-  static std::shared_ptr<spdlog::logger> tcp();
-  static std::shared_ptr<spdlog::logger> sql();
-  static std::shared_ptr<spdlog::logger> perfdata();
-  static std::shared_ptr<spdlog::logger> lua();
-  static std::shared_ptr<spdlog::logger> processing();
   static std::shared_ptr<spdlog::logger> bam();
+  static std::shared_ptr<spdlog::logger> bbdo();
+  static std::shared_ptr<spdlog::logger> config();
+  static std::shared_ptr<spdlog::logger> core();
+  static std::shared_ptr<spdlog::logger> influxdb();
+  static std::shared_ptr<spdlog::logger> lua();
+  static std::shared_ptr<spdlog::logger> perfdata();
+  static std::shared_ptr<spdlog::logger> processing();
+  static std::shared_ptr<spdlog::logger> sql();
+  static std::shared_ptr<spdlog::logger> tcp();
+  static std::shared_ptr<spdlog::logger> tls();
 };
 
 CCB_END();

--- a/core/src/log_v2.cc
+++ b/core/src/log_v2.cc
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Centreon
+** Copyright 2020-2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -45,30 +45,32 @@ log_v2& log_v2::instance() {
 
 log_v2::log_v2() {
   auto null_sink = std::make_shared<sinks::null_sink_mt>();
-  _tls_log = std::make_shared<logger>("tls", null_sink);
-  _bbdo_log = std::make_shared<logger>("bbdo", null_sink);
-  _tcp_log = std::make_shared<logger>("tcp", null_sink);
-  _core_log = std::make_shared<logger>("core", null_sink);
-  _config_log = std::make_shared<logger>("config", null_sink);
-  _sql_log = std::make_shared<logger>("sql", null_sink);
-  _perfdata_log = std::make_shared<logger>("perfdata", null_sink);
-  _lua_log = std::make_shared<logger>("lua", null_sink);
-  _processing_log = std::make_shared<logger>("processing", null_sink);
   _bam_log = std::make_shared<logger>("bam", null_sink);
+  _bbdo_log = std::make_shared<logger>("bbdo", null_sink);
+  _config_log = std::make_shared<logger>("config", null_sink);
+  _core_log = std::make_shared<logger>("core", null_sink);
+  _influxdb_log = std::make_shared<logger>("influxdb", null_sink);
+  _lua_log = std::make_shared<logger>("lua", null_sink);
+  _perfdata_log = std::make_shared<logger>("perfdata", null_sink);
+  _processing_log = std::make_shared<logger>("processing", null_sink);
+  _sql_log = std::make_shared<logger>("sql", null_sink);
+  _tcp_log = std::make_shared<logger>("tcp", null_sink);
+  _tls_log = std::make_shared<logger>("tls", null_sink);
 }
 
 log_v2::~log_v2() {
   _core_log->info("log finished");
-  _tls_log->flush();
-  _bbdo_log->flush();
-  _tcp_log->flush();
-  _core_log->flush();
-  _config_log->flush();
-  _sql_log->flush();
-  _perfdata_log->flush();
-  _lua_log->flush();
-  _processing_log->flush();
   _bam_log->flush();
+  _bbdo_log->flush();
+  _config_log->flush();
+  _core_log->flush();
+  _influxdb_log->flush();
+  _lua_log->flush();
+  _perfdata_log->flush();
+  _processing_log->flush();
+  _sql_log->flush();
+  _tcp_log->flush();
+  _tls_log->flush();
 }
 
 static auto json_validate = [](Json const& js) -> bool {
@@ -131,6 +133,8 @@ bool log_v2::load(const char* file,
         std::shared_ptr<logger>* l;
         if (entry["name"].string_value() == "core")
           l = &_core_log;
+        else if (entry["name"].string_value() == "influxdb")
+          l = &_influxdb_log;
         else if (entry["name"].string_value() == "config")
           l = &_config_log;
         else if (entry["name"].string_value() == "tls")
@@ -169,44 +173,48 @@ bool log_v2::load(const char* file,
   return false;
 }
 
-std::shared_ptr<spdlog::logger> log_v2::core() {
-  return instance()._core_log;
-}
-
-std::shared_ptr<spdlog::logger> log_v2::config() {
-  return instance()._config_log;
-}
-
-std::shared_ptr<spdlog::logger> log_v2::tls() {
-  return instance()._tls_log;
+std::shared_ptr<spdlog::logger> log_v2::bam() {
+  return instance()._bam_log;
 }
 
 std::shared_ptr<spdlog::logger> log_v2::bbdo() {
   return instance()._bbdo_log;
 }
 
-std::shared_ptr<spdlog::logger> log_v2::tcp() {
-  return instance()._tcp_log;
+std::shared_ptr<spdlog::logger> log_v2::config() {
+  return instance()._config_log;
 }
 
-std::shared_ptr<spdlog::logger> log_v2::sql() {
-  return instance()._sql_log;
+std::shared_ptr<spdlog::logger> log_v2::core() {
+  return instance()._core_log;
 }
 
-std::shared_ptr<spdlog::logger> log_v2::perfdata() {
-  return instance()._perfdata_log;
+std::shared_ptr<spdlog::logger> log_v2::influxdb() {
+  return instance()._influxdb_log;
 }
 
 std::shared_ptr<spdlog::logger> log_v2::lua() {
   return instance()._lua_log;
 }
 
+std::shared_ptr<spdlog::logger> log_v2::perfdata() {
+  return instance()._perfdata_log;
+}
+
 std::shared_ptr<spdlog::logger> log_v2::processing() {
   return instance()._processing_log;
 }
 
-std::shared_ptr<spdlog::logger> log_v2::bam() {
-  return instance()._bam_log;
+std::shared_ptr<spdlog::logger> log_v2::sql() {
+  return instance()._sql_log;
+}
+
+std::shared_ptr<spdlog::logger> log_v2::tcp() {
+  return instance()._tcp_log;
+}
+
+std::shared_ptr<spdlog::logger> log_v2::tls() {
+  return instance()._tls_log;
 }
 
 const std::string& log_v2::log_name() const {

--- a/core/test/rpc/brokerrpc.cc
+++ b/core/test/rpc/brokerrpc.cc
@@ -66,13 +66,13 @@ TEST_F(BrokerRpc, GetVersion) {
   brokerrpc brpc("0.0.0.0", 40000, "test");
   auto output = execute("GetVersion");
 #if CENTREON_BROKER_PATCH == 0
-  ASSERT_EQ(output.size(), 2);
+  ASSERT_EQ(output.size(), 2u);
   ASSERT_EQ(output.front(), oss.str());
   oss.str("");
   oss << "minor: " << version::minor;
   ASSERT_EQ(output.back(), oss.str());
 #else
-  ASSERT_EQ(output.size(), 3);
+  ASSERT_EQ(output.size(), 3u);
   ASSERT_EQ(output.front(), oss.str());
   oss.str("");
   oss << "patch: " << version::patch;

--- a/influxdb/inc/com/centreon/broker/influxdb/influxdb12.hh
+++ b/influxdb/inc/com/centreon/broker/influxdb/influxdb12.hh
@@ -82,7 +82,9 @@ class influxdb12 : public influxdb::influxdb {
   macro_cache const& _cache;
 
   void _connect_socket();
-  bool _check_answer_string(std::string const& ans);
+  bool _check_answer_string(std::string const& ans,
+                            const std::string& addr,
+                            uint16_t port);
   void _create_queries(std::string const& user,
                        std::string const& passwd,
                        std::string const& db,

--- a/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
+++ b/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
@@ -52,7 +52,8 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
   std::queue<std::vector<char>> _read_queue;
 
   std::atomic_bool _closed;
-  std::string _peer;
+  std::string _address;
+  uint16_t _port;
 
  public:
   typedef std::shared_ptr<tcp_connection> pointer;
@@ -78,8 +79,10 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
   void close();
 
   bool is_closed() const;
-  const std::string& peer() const;
-  void update_peer();
+  void update_peer(asio::error_code& ec);
+  const std::string peer() const;
+  const std::string& address() const;
+  uint16_t port() const;
 };
 
 }  // namespace tcp

--- a/tcp/src/acceptor.cc
+++ b/tcp/src/acceptor.cc
@@ -47,7 +47,6 @@ acceptor::acceptor(uint16_t port, int32_t read_timeout)
  */
 acceptor::~acceptor() noexcept {
   log_v2::tcp()->trace("acceptor destroyed");
-  std::error_code ec;
   if (_acceptor) {
     tcp_async::instance().stop_acceptor(_acceptor);
   }
@@ -68,7 +67,6 @@ void acceptor::add_child(std::string const& child) {
  *
  */
 std::shared_ptr<io::stream> acceptor::open() {
-  log_v2::tcp()->debug("tcp::acceptor open...");
   if (!_acceptor) {
     _acceptor = tcp_async::instance().create_acceptor(_port);
     tcp_async::instance().start_acceptor(_acceptor);
@@ -78,12 +76,12 @@ std::shared_ptr<io::stream> acceptor::open() {
   const uint32_t timeout_s = 3;
   auto conn = tcp_async::instance().get_connection(_acceptor, timeout_s);
   if (conn) {
-    log_v2::tcp()->debug("acceptor gets a new connection from {}:{}",
-                         conn->socket().remote_endpoint().address().to_string(),
-                         conn->socket().remote_endpoint().port());
+    assert(conn->port());
+    log_v2::tcp()->debug("acceptor gets a new connection from {}",
+                         conn->peer());
     return std::make_shared<stream>(conn, -1);
   }
-  return std::shared_ptr<stream>();
+  return nullptr;
 }
 
 bool acceptor::is_ready() const {

--- a/tcp/src/connector.cc
+++ b/tcp/src/connector.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 - 2020 Centreon (https://www.centreon.com/)
+ * Copyright 2011 - 2021 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,9 +71,10 @@ std::shared_ptr<io::stream> connector::open() {
   } catch (const std::exception& e) {
     if (_is_ready_count < 30)
       _is_ready_count++;
-    log_v2::tcp()->debug("Unable to establish the connection to {}:{} (attempt {}): {}",
-                         _host, _port, _is_ready_count, e.what());
-    return std::shared_ptr<stream>();
+    log_v2::tcp()->debug(
+        "Unable to establish the connection to {}:{} (attempt {}): {}", _host,
+        _port, _is_ready_count, e.what());
+    return nullptr;
   }
 }
 

--- a/tcp/src/stream.cc
+++ b/tcp/src/stream.cc
@@ -58,6 +58,7 @@ stream::stream(std::string const& host, uint16_t port, int32_t read_timeout)
       _connection(tcp_async::instance().create_connection(host, port)),
       _parent(nullptr) {
   _total_tcp_count++;
+  log_v2::tcp()->trace("New stream to {}:{}", _host, _port);
   log_v2::tcp()->info(
       "{} TCP streams are configured on a thread pool of {} threads",
       _total_tcp_count, pool::instance().get_current_size());
@@ -72,12 +73,13 @@ stream::stream(std::string const& host, uint16_t port, int32_t read_timeout)
  */
 stream::stream(tcp_connection::pointer conn, int32_t read_timeout)
     : io::stream("TCP"),
-      _host(conn->socket().remote_endpoint().address().to_string()),
-      _port(conn->socket().remote_endpoint().port()),
+      _host{conn->address()},
+      _port{conn->port()},
       _read_timeout(read_timeout),
       _connection(conn),
       _parent(nullptr) {
   _total_tcp_count++;
+  log_v2::tcp()->info("New stream to {}:{}", _host, _port);
   log_v2::tcp()->info(
       "{} TCP streams are configured on a thread pool of {} threads",
       _total_tcp_count, pool::instance().get_current_size());
@@ -137,7 +139,7 @@ bool stream::read(std::shared_ptr<io::data>& d, time_t deadline) {
   bool timeout = false;
   d.reset(new io::raw(_connection->read(deadline, &timeout)));
   std::shared_ptr<io::raw> data{std::static_pointer_cast<io::raw>(d)};
-  log_v2::tcp()->debug("TCP Read done : {} bytes", data->get_buffer().size());
+  log_v2::tcp()->trace("TCP Read done : {} bytes", data->get_buffer().size());
   return !timeout;
 }
 
@@ -171,7 +173,7 @@ int32_t stream::write(std::shared_ptr<io::data> const& d) {
 
   if (d->type() == io::raw::static_type()) {
     std::shared_ptr<io::raw> r(std::static_pointer_cast<io::raw>(d));
-    log_v2::tcp()->debug("TCP: write request of {} bytes to peer '{}:{}'",
+    log_v2::tcp()->trace("TCP: write request of {} bytes to peer '{}:{}'",
                          r->size(), _host, _port);
     log_v2::tcp()->trace("write {} bytes", r->size());
     std::error_code err;

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -193,12 +193,19 @@ void tcp_async::handle_accept(std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
                               const asio::error_code& ec) {
   /* If we got a connection, we store it */
   if (!ec) {
-    new_connection->update_peer();
-    std::lock_guard<std::mutex> lck(_acceptor_con_m);
-    std::time_t now = std::time(nullptr);
-    _acceptor_available_con.insert(
-        std::make_pair(acceptor.get(), std::make_pair(new_connection, now)));
-    _acceptor_con_cv.notify_one();
+    asio::error_code ecc;
+    new_connection->update_peer(ecc);
+    if (ecc)
+      log_v2::tcp()->error(
+          "tcp acceptor handling connection: unable to get peer endpoint: {}",
+          ecc.message());
+    else {
+      std::lock_guard<std::mutex> lck(_acceptor_con_m);
+      std::time_t now = std::time(nullptr);
+      _acceptor_available_con.insert(
+          std::make_pair(acceptor.get(), std::make_pair(new_connection, now)));
+      _acceptor_con_cv.notify_one();
+    }
     start_acceptor(acceptor);
   } else
     log_v2::tcp()->error("acceptor error: {}", ec.message());


### PR DESCRIPTION
## Description

Getting the remote endpoint from a socket is implemented in two ways:
* a method returning an exception on failure
* a method with an error_code as parameter that the caller must check.

In our code, we called the first one but did not catch the eventual exception.

REFS: MON-6904

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
