### PR TITLE
fix(tcp): getting a remote endpoint from a socket may fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ GnuTLS query was not understood on RedHat 8 and Centos8.
 
 Converts theses events into trace.
 
-*tcp*
+*TCP*
 
-Connections can fail when many pollers establish connection to cbd. This should
-be fixed with this new version.
-
-When cbd is stopped, sometimes centengine cannot reconnect. This is fixed now.
+* Connections can fail when many pollers establish connection to cbd. This
+should be fixed with this new version.
+* When cbd is stopped, sometimes centengine cannot reconnect. This is fixed now.
+* if the connection fails to get the remote endpoint, the error was not catched
+  and could break cbd/centengine.
 
 ### Build
 

--- a/core/inc/com/centreon/broker/log_v2.hh
+++ b/core/inc/com/centreon/broker/log_v2.hh
@@ -31,16 +31,17 @@ CCB_BEGIN()
 class log_v2 {
   static std::map<std::string, spdlog::level::level_enum> _levels_map;
   std::string _log_name;
-  std::shared_ptr<spdlog::logger> _core_log;
-  std::shared_ptr<spdlog::logger> _config_log;
-  std::shared_ptr<spdlog::logger> _tcp_log;
-  std::shared_ptr<spdlog::logger> _bbdo_log;
-  std::shared_ptr<spdlog::logger> _tls_log;
-  std::shared_ptr<spdlog::logger> _sql_log;
-  std::shared_ptr<spdlog::logger> _perfdata_log;
-  std::shared_ptr<spdlog::logger> _lua_log;
-  std::shared_ptr<spdlog::logger> _processing_log;
   std::shared_ptr<spdlog::logger> _bam_log;
+  std::shared_ptr<spdlog::logger> _bbdo_log;
+  std::shared_ptr<spdlog::logger> _config_log;
+  std::shared_ptr<spdlog::logger> _core_log;
+  std::shared_ptr<spdlog::logger> _influxdb_log;
+  std::shared_ptr<spdlog::logger> _lua_log;
+  std::shared_ptr<spdlog::logger> _perfdata_log;
+  std::shared_ptr<spdlog::logger> _processing_log;
+  std::shared_ptr<spdlog::logger> _sql_log;
+  std::shared_ptr<spdlog::logger> _tcp_log;
+  std::shared_ptr<spdlog::logger> _tls_log;
   std::mutex _load_m;
 
   log_v2();
@@ -57,6 +58,7 @@ class log_v2 {
   static std::shared_ptr<spdlog::logger> bbdo();
   static std::shared_ptr<spdlog::logger> config();
   static std::shared_ptr<spdlog::logger> core();
+  static std::shared_ptr<spdlog::logger> influxdb();
   static std::shared_ptr<spdlog::logger> lua();
   static std::shared_ptr<spdlog::logger> perfdata();
   static std::shared_ptr<spdlog::logger> processing();

--- a/core/src/log_v2.cc
+++ b/core/src/log_v2.cc
@@ -48,30 +48,32 @@ log_v2& log_v2::instance() {
 
 log_v2::log_v2() {
   auto null_sink = std::make_shared<sinks::null_sink_mt>();
-  _tls_log = std::make_shared<logger>("tls", null_sink);
-  _bbdo_log = std::make_shared<logger>("bbdo", null_sink);
-  _tcp_log = std::make_shared<logger>("tcp", null_sink);
-  _core_log = std::make_shared<logger>("core", null_sink);
-  _config_log = std::make_shared<logger>("config", null_sink);
-  _sql_log = std::make_shared<logger>("sql", null_sink);
-  _perfdata_log = std::make_shared<logger>("perfdata", null_sink);
-  _lua_log = std::make_shared<logger>("lua", null_sink);
-  _processing_log = std::make_shared<logger>("processing", null_sink);
   _bam_log = std::make_shared<logger>("bam", null_sink);
+  _bbdo_log = std::make_shared<logger>("bbdo", null_sink);
+  _config_log = std::make_shared<logger>("config", null_sink);
+  _core_log = std::make_shared<logger>("core", null_sink);
+  _influxdb_log = std::make_shared<logger>("influxdb", null_sink);
+  _lua_log = std::make_shared<logger>("lua", null_sink);
+  _perfdata_log = std::make_shared<logger>("perfdata", null_sink);
+  _processing_log = std::make_shared<logger>("processing", null_sink);
+  _sql_log = std::make_shared<logger>("sql", null_sink);
+  _tcp_log = std::make_shared<logger>("tcp", null_sink);
+  _tls_log = std::make_shared<logger>("tls", null_sink);
 }
 
 log_v2::~log_v2() {
   _core_log->info("log finished");
-  _tls_log->flush();
-  _bbdo_log->flush();
-  _tcp_log->flush();
-  _core_log->flush();
-  _config_log->flush();
-  _sql_log->flush();
-  _perfdata_log->flush();
-  _lua_log->flush();
-  _processing_log->flush();
   _bam_log->flush();
+  _bbdo_log->flush();
+  _config_log->flush();
+  _core_log->flush();
+  _influxdb_log->flush();
+  _lua_log->flush();
+  _perfdata_log->flush();
+  _processing_log->flush();
+  _sql_log->flush();
+  _tcp_log->flush();
+  _tls_log->flush();
 }
 
 void log_v2::apply(const config::state& conf) {
@@ -95,15 +97,16 @@ void log_v2::apply(const config::state& conf) {
   _core_log->flush_on(level::info);
   _core_log->info("{} : log started", _log_name);
 
-  _config_log = std::make_shared<logger>("config", null_sink);
-  _tls_log = std::make_shared<logger>("tls", null_sink);
-  _tcp_log = std::make_shared<logger>("tcp", null_sink);
-  _bbdo_log = std::make_shared<logger>("bbdo", null_sink);
-  _sql_log = std::make_shared<logger>("sql", null_sink);
-  _perfdata_log = std::make_shared<logger>("perfdata", null_sink);
-  _lua_log = std::make_shared<logger>("lua", null_sink);
-  _processing_log = std::make_shared<logger>("processing", null_sink);
   _bam_log = std::make_shared<logger>("bam", null_sink);
+  _bbdo_log = std::make_shared<logger>("bbdo", null_sink);
+  _config_log = std::make_shared<logger>("config", null_sink);
+  _influxdb_log = std::make_shared<logger>("influxdb", null_sink);
+  _lua_log = std::make_shared<logger>("lua", null_sink);
+  _perfdata_log = std::make_shared<logger>("perfdata", null_sink);
+  _processing_log = std::make_shared<logger>("processing", null_sink);
+  _sql_log = std::make_shared<logger>("sql", null_sink);
+  _tcp_log = std::make_shared<logger>("tcp", null_sink);
+  _tls_log = std::make_shared<logger>("tls", null_sink);
 
   for (auto it = log.loggers.begin(), end = log.loggers.end(); it != end;
        ++it) {
@@ -128,6 +131,8 @@ void log_v2::apply(const config::state& conf) {
       l = &_processing_log;
     else if (it->first == "bam")
       l = &_bam_log;
+    else if (it->first == "influxdb")
+      l = &_influxdb_log;
     else
       continue;
 
@@ -137,44 +142,48 @@ void log_v2::apply(const config::state& conf) {
   }
 }
 
-std::shared_ptr<spdlog::logger> log_v2::core() {
-  return instance()._core_log;
-}
-
-std::shared_ptr<spdlog::logger> log_v2::config() {
-  return instance()._config_log;
-}
-
-std::shared_ptr<spdlog::logger> log_v2::tls() {
-  return instance()._tls_log;
+std::shared_ptr<spdlog::logger> log_v2::bam() {
+  return instance()._bam_log;
 }
 
 std::shared_ptr<spdlog::logger> log_v2::bbdo() {
   return instance()._bbdo_log;
 }
 
-std::shared_ptr<spdlog::logger> log_v2::tcp() {
-  return instance()._tcp_log;
+std::shared_ptr<spdlog::logger> log_v2::config() {
+  return instance()._config_log;
 }
 
-std::shared_ptr<spdlog::logger> log_v2::sql() {
-  return instance()._sql_log;
+std::shared_ptr<spdlog::logger> log_v2::core() {
+  return instance()._core_log;
 }
 
-std::shared_ptr<spdlog::logger> log_v2::perfdata() {
-  return instance()._perfdata_log;
+std::shared_ptr<spdlog::logger> log_v2::influxdb() {
+  return instance()._influxdb_log;
 }
 
 std::shared_ptr<spdlog::logger> log_v2::lua() {
   return instance()._lua_log;
 }
 
+std::shared_ptr<spdlog::logger> log_v2::perfdata() {
+  return instance()._perfdata_log;
+}
+
 std::shared_ptr<spdlog::logger> log_v2::processing() {
   return instance()._processing_log;
 }
 
-std::shared_ptr<spdlog::logger> log_v2::bam() {
-  return instance()._bam_log;
+std::shared_ptr<spdlog::logger> log_v2::sql() {
+  return instance()._sql_log;
+}
+
+std::shared_ptr<spdlog::logger> log_v2::tcp() {
+  return instance()._tcp_log;
+}
+
+std::shared_ptr<spdlog::logger> log_v2::tls() {
+  return instance()._tls_log;
 }
 
 const std::string& log_v2::log_name() const {

--- a/core/test/rpc/brokerrpc.cc
+++ b/core/test/rpc/brokerrpc.cc
@@ -65,13 +65,13 @@ TEST_F(BrokerRpc, GetVersion) {
   brokerrpc brpc("0.0.0.0", 40000, "test");
   auto output = execute("GetVersion");
 #if CENTREON_BROKER_PATCH == 0
-  ASSERT_EQ(output.size(), 2);
+  ASSERT_EQ(output.size(), 2u);
   ASSERT_EQ(output.front(), oss.str());
   oss.str("");
   oss << "minor: " << version::minor;
   ASSERT_EQ(output.back(), oss.str());
 #else
-  ASSERT_EQ(output.size(), 3);
+  ASSERT_EQ(output.size(), 3u);
   ASSERT_EQ(output.front(), oss.str());
   oss.str("");
   oss << "patch: " << version::patch;

--- a/influxdb/inc/com/centreon/broker/influxdb/influxdb12.hh
+++ b/influxdb/inc/com/centreon/broker/influxdb/influxdb12.hh
@@ -82,7 +82,9 @@ class influxdb12 : public influxdb::influxdb {
   macro_cache const& _cache;
 
   void _connect_socket();
-  bool _check_answer_string(std::string const& ans);
+  bool _check_answer_string(std::string const& ans,
+                            const std::string& addr,
+                            uint16_t port);
   void _create_queries(std::string const& user,
                        std::string const& passwd,
                        std::string const& db,

--- a/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
+++ b/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
@@ -52,7 +52,8 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
   std::queue<std::vector<char>> _read_queue;
 
   std::atomic_bool _closed;
-  std::string _peer;
+  std::string _address;
+  uint16_t _port;
 
  public:
   typedef std::shared_ptr<tcp_connection> pointer;
@@ -78,8 +79,10 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
   void close();
 
   bool is_closed() const;
-  const std::string& peer() const;
-  void update_peer();
+  void update_peer(asio::error_code& ec);
+  const std::string peer() const;
+  const std::string& address() const;
+  uint16_t port() const;
 };
 
 }  // namespace tcp

--- a/tcp/src/acceptor.cc
+++ b/tcp/src/acceptor.cc
@@ -73,10 +73,10 @@ std::unique_ptr<io::stream> acceptor::open() {
   const uint32_t timeout_s = 3;
   auto conn = tcp_async::instance().get_connection(_acceptor, timeout_s);
   if (conn) {
-    log_v2::tcp()->debug("acceptor gets a new connection from {}:{}",
-                         conn->socket().remote_endpoint().address().to_string(),
-                         conn->socket().remote_endpoint().port());
-    return std::unique_ptr<stream>(new stream(conn, -1));
+    assert(conn->port());
+    log_v2::tcp()->debug("acceptor gets a new connection from {}",
+                         conn->peer());
+    return std::make_unique<stream>(conn, -1);
   }
   return nullptr;
 }

--- a/tcp/src/connector.cc
+++ b/tcp/src/connector.cc
@@ -64,9 +64,9 @@ std::unique_ptr<io::stream> connector::open() {
   log_v2::tcp()->info("TCP: connecting to {}:{}", _host, _port);
   try {
     std::unique_ptr<stream> retval =
-        std::unique_ptr<stream>(new stream(_host, _port, _read_timeout));
+        std::make_unique<stream>(_host, _port, _read_timeout);
     _is_ready_count = 0;
-    return std::move(retval);
+    return retval;
   } catch (const std::exception& e) {
     if (_is_ready_count < 30)
       _is_ready_count++;


### PR DESCRIPTION
## Description

Getting the remote endpoint from a socket is implemented in two ways:
* a method returning an exception on failure
* a method with an error_code as parameter that the caller must check.

In our code, we called the first one but did not catch the eventual exception.

REFS: MON-6904

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
