### PR TITLE
fix(mysql): New method mysql_connection::ping()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Bug fix
 
+*SQL*
+
+Broker stores its connections to the database in an array. Once they are
+established, it does not test if they are still valid after a laps of time.
+But we know that MariaDB closes inactive connections. So here, we have added
+a check to verify if a connection is still ok.
+
 *RPC*
 
 A memory leak has been fixed. The reflection module is removed because not used

--- a/core/inc/com/centreon/broker/mysql_connection.hh
+++ b/core/inc/com/centreon/broker/mysql_connection.hh
@@ -156,6 +156,7 @@ class mysql_connection {
   bool match_config(database_config const& db_cfg) const;
   int get_tasks_count() const;
   bool is_finished() const;
+  bool ping();
   bool is_in_error() const;
   void clear_error();
   std::string get_error_message();

--- a/core/src/mysql_connection.cc
+++ b/core/src/mysql_connection.cc
@@ -438,6 +438,21 @@ bool mysql_connection::is_finished() const {
   return _finished;
 }
 
+/**
+ * @brief This function checks if the connection to the database is still
+ * active. It returns true in that case, false otherwise.
+ *
+ * @return a boolean.
+ */
+bool mysql_connection::ping() {
+  int ret = mysql_ping(_conn);
+  if (ret) {
+    _finish(nullptr);
+    return false;
+  }
+  return true;
+}
+
 std::string mysql_connection::_get_stack() {
   std::string retval;
   for (std::shared_ptr<mysql_task> t : _tasks_list) {

--- a/core/src/mysql_manager.cc
+++ b/core/src/mysql_manager.cc
@@ -85,13 +85,14 @@ std::vector<std::shared_ptr<mysql_connection>> mysql_manager::get_connections(
   }
 
   {
-    uint32_t current_connection(0);
+    uint32_t current_connection{0};
     std::lock_guard<std::mutex> lock(_cfg_mutex);
-    for (std::shared_ptr<mysql_connection>& c : _connection) {
+    for (std::shared_ptr<mysql_connection> c : _connection) {
       // Is this thread matching what the configuration needs?
-      if (c->match_config(db_cfg) && !c->is_finished() && !c->is_in_error()) {
+      if (c->match_config(db_cfg) && !c->is_finished() && !c->is_in_error() &&
+          c->ping()) {
         // Yes
-        retval.push_back(c);
+        retval.emplace_back(c);
         ++current_connection;
         if (current_connection >= connection_count)
           return retval;

--- a/stats/test/stats.cc
+++ b/stats/test/stats.cc
@@ -252,7 +252,7 @@ TEST_F(StatsTest, BuilderWithEndpoints) {
 
   ASSERT_TRUE(result.is_object());
   ASSERT_EQ(result["version"].get<std::string>(), CENTREON_BROKER_VERSION);
-  ASSERT_EQ(result["pid"].get<uint32_t>(), getpid());
+  ASSERT_EQ(result["pid"].get<int32_t>(), getpid());
   ASSERT_TRUE(result["now"].is_string());
   ASSERT_TRUE(result["asio_version"].is_string());
   ASSERT_TRUE(result["mysql manager"].is_object());


### PR DESCRIPTION
## Description

This is useful to give an operational connection and not one already
disconnected.

REFS: MON-6917

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
