### PR TITLE
fix(bam): when a new ba is created, start_time is correctly initialized.

### DIFF
--- a/bam/inc/com/centreon/broker/bam/ba_duration_event.hh
+++ b/bam/inc/com/centreon/broker/bam/ba_duration_event.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2014 Centreon
+** Copyright 2014, 2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/bam/inc/com/centreon/broker/bam/kpi_event.hh
+++ b/bam/inc/com/centreon/broker/bam/kpi_event.hh
@@ -45,7 +45,7 @@ class kpi_event : public io::data {
 
  public:
   typedef impact_values::state state;
-  kpi_event(uint32_t kpi_id, uint32_t ba_id);
+  kpi_event(uint32_t kpi_id, uint32_t ba_id, time_t start_time);
   kpi_event(const kpi_event& other);
   ~kpi_event() noexcept = default;
   kpi_event& operator=(const kpi_event& other);

--- a/bam/src/ba_duration_event.cc
+++ b/bam/src/ba_duration_event.cc
@@ -1,5 +1,5 @@
 /*
-** Copyright 2014-2015 Centreon
+** Copyright 2014-2015, 2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/bam/src/configuration/applier/ba.cc
+++ b/bam/src/configuration/applier/ba.cc
@@ -124,8 +124,8 @@ void applier::ba::apply(bam::configuration::state::bas const& my_bas,
   to_delete.clear();
 
   // Create new objects.
-  for (bam::configuration::state::bas::iterator it(to_create.begin()),
-       end(to_create.end());
+  for (bam::configuration::state::bas::iterator it = to_create.begin(),
+                                                end = to_create.end();
        it != end; ++it) {
     log_v2::bam()->info("BAM: creating BA {} ('{}')", it->first,
                         it->second.get_name());

--- a/bam/src/configuration/kpi.cc
+++ b/bam/src/configuration/kpi.cc
@@ -57,7 +57,7 @@ kpi::kpi(uint32_t id,
       _impact_warning(warning),
       _impact_critical(critical),
       _impact_unknown(unknown),
-      _event(_id, _ba_id) {}
+      _event(_id, _ba_id, ::time(nullptr)) {}
 
 /**
  *  Copy constructor.
@@ -117,7 +117,7 @@ kpi& kpi::operator=(kpi const& other) {
     _impact_unknown = other._impact_unknown;
     _event = other._event;
   }
-  return (*this);
+  return *this;
 }
 
 /**
@@ -128,20 +128,20 @@ kpi& kpi::operator=(kpi const& other) {
  *  @return True if both objects are equal.
  */
 bool kpi::operator==(kpi const& other) const {
-  return ((_id == other._id) && (_state_type == other._state_type) &&
-          (_host_id == other._host_id) && (_service_id == other._service_id) &&
-          (_ba_id == other._ba_id) &&
-          (_indicator_ba_id == other._indicator_ba_id) &&
-          (_meta_id == other._meta_id) && (_boolexp_id == other._boolexp_id) &&
-          (_status == other._status) && (_last_level == other._last_level) &&
-          (_downtimed == other._downtimed) &&
-          (_acknowledged == other._acknowledged) &&
-          (_ignore_downtime == other._ignore_downtime) &&
-          (_ignore_acknowledgement == other._ignore_acknowledgement) &&
-          (_impact_warning == other._impact_warning) &&
-          (_impact_critical == other._impact_critical) &&
-          (_impact_unknown == other._impact_unknown) &&
-          (_event == other._event));
+  return _id == other._id && _state_type == other._state_type &&
+          _host_id == other._host_id && _service_id == other._service_id &&
+          _ba_id == other._ba_id &&
+          _indicator_ba_id == other._indicator_ba_id &&
+          _meta_id == other._meta_id && _boolexp_id == other._boolexp_id &&
+          _status == other._status && _last_level == other._last_level &&
+          _downtimed == other._downtimed &&
+          _acknowledged == other._acknowledged &&
+          _ignore_downtime == other._ignore_downtime &&
+          _ignore_acknowledgement == other._ignore_acknowledgement &&
+          _impact_warning == other._impact_warning &&
+          _impact_critical == other._impact_critical &&
+          _impact_unknown == other._impact_unknown &&
+          _event == other._event;
 }
 
 /**
@@ -152,7 +152,7 @@ bool kpi::operator==(kpi const& other) const {
  *  @return True if both objects are inequal.
  */
 bool kpi::operator!=(kpi const& other) const {
-  return (!operator==(other));
+  return !operator==(other);
 }
 
 /**
@@ -161,7 +161,7 @@ bool kpi::operator!=(kpi const& other) const {
  *  @return  The id value.
  */
 unsigned kpi::get_id() const {
-  return (_id);
+  return _id;
 }
 
 /**
@@ -179,7 +179,7 @@ void kpi::set_id(uint32_t id) {
  *  @return  The state type.
  */
 short kpi::get_state_type() const {
-  return (_state_type);
+  return _state_type;
 }
 
 /**
@@ -188,7 +188,7 @@ short kpi::get_state_type() const {
  *  @return  The host id.
  */
 uint32_t kpi::get_host_id() const {
-  return (_host_id);
+  return _host_id;
 }
 
 /**
@@ -197,7 +197,7 @@ uint32_t kpi::get_host_id() const {
  *  @return  The service id.
  */
 uint32_t kpi::get_service_id() const {
-  return (_service_id);
+  return _service_id;
 }
 
 /**
@@ -206,7 +206,7 @@ uint32_t kpi::get_service_id() const {
  *  @return Whether this is a service or not.
  */
 bool kpi::is_service() const {
-  return (_service_id != 0);
+  return _service_id != 0;
 }
 
 /**
@@ -215,7 +215,7 @@ bool kpi::is_service() const {
  *  @return Whether this is a business activity abstraction or not.
  */
 bool kpi::is_ba() const {
-  return (_indicator_ba_id != 0);
+  return _indicator_ba_id != 0;
 }
 
 /**
@@ -224,7 +224,7 @@ bool kpi::is_ba() const {
  *  @return True if this KPI is a meta-service.
  */
 bool kpi::is_meta() const {
-  return (_meta_id != 0);
+  return _meta_id != 0;
 }
 
 /**
@@ -233,7 +233,7 @@ bool kpi::is_meta() const {
  *  @return True if this KPI is a boolean expression.
  */
 bool kpi::is_boolexp() const {
-  return (_boolexp_id != 0);
+  return _boolexp_id != 0;
 }
 
 /**
@@ -242,7 +242,7 @@ bool kpi::is_boolexp() const {
  *  @return The id of the business activity.
  */
 uint32_t kpi::get_ba_id() const {
-  return (_ba_id);
+  return _ba_id;
 }
 
 /**
@@ -251,7 +251,7 @@ uint32_t kpi::get_ba_id() const {
  *  @return The ID of the BA attached to this KPI.
  */
 uint32_t kpi::get_indicator_ba_id() const {
-  return (_indicator_ba_id);
+  return _indicator_ba_id;
 }
 
 /**
@@ -260,7 +260,7 @@ uint32_t kpi::get_indicator_ba_id() const {
  *  @return Meta-ID of this KPI.
  */
 uint32_t kpi::get_meta_id() const {
-  return (_meta_id);
+  return _meta_id;
 }
 
 /**
@@ -269,7 +269,7 @@ uint32_t kpi::get_meta_id() const {
  *  @return Boolean expression ID of this KPI.
  */
 uint32_t kpi::get_boolexp_id() const {
-  return (_boolexp_id);
+  return _boolexp_id;
 }
 
 /**
@@ -278,7 +278,7 @@ uint32_t kpi::get_boolexp_id() const {
  *  @return The status.
  */
 short kpi::get_status() const {
-  return (_status);
+  return _status;
 }
 
 /**
@@ -287,7 +287,7 @@ short kpi::get_status() const {
  *  @return The last level of this kpi.
  */
 short kpi::get_last_level() const {
-  return (_last_level);
+  return _last_level;
 }
 
 /**
@@ -296,7 +296,7 @@ short kpi::get_last_level() const {
  *  @return Has this business interest been downtimed?
  */
 bool kpi::is_downtimed() const {
-  return (_downtimed);
+  return _downtimed;
 }
 
 /**
@@ -305,7 +305,7 @@ bool kpi::is_downtimed() const {
  *  @return Whether it has been acknowledged.
  */
 bool kpi::is_acknowledged() const {
-  return (_acknowledged);
+  return _acknowledged;
 }
 
 /**
@@ -314,7 +314,7 @@ bool kpi::is_acknowledged() const {
  *  @return Whether or not the downtime is relevant.
  */
 bool kpi::ignore_downtime() const {
-  return (_ignore_downtime);
+  return _ignore_downtime;
 }
 
 /**
@@ -323,7 +323,7 @@ bool kpi::ignore_downtime() const {
  *  @return Whether or not the acknowledgements are applicable.
  */
 bool kpi::ignore_acknowledgement() const {
-  return (_ignore_acknowledgement);
+  return _ignore_acknowledgement;
 }
 
 /**
@@ -332,7 +332,7 @@ bool kpi::ignore_acknowledgement() const {
  *  @return The get business impact of a warning at this level.
  */
 double kpi::get_impact_warning() const {
-  return (_impact_warning);
+  return _impact_warning;
 }
 
 /**
@@ -341,7 +341,7 @@ double kpi::get_impact_warning() const {
  *  @return The get business impact of a criticality at this level.
  */
 double kpi::get_impact_critical() const {
-  return (_impact_critical);
+  return _impact_critical;
 }
 
 /**
@@ -350,7 +350,7 @@ double kpi::get_impact_critical() const {
  *  @return The get business impact of an unknown status at this level.
  */
 double kpi::get_impact_unknown() const {
-  return (_impact_unknown);
+  return _impact_unknown;
 }
 
 /**
@@ -359,7 +359,7 @@ double kpi::get_impact_unknown() const {
  *  @return  The opened event associated with this kpi.
  */
 com::centreon::broker::bam::kpi_event const& kpi::get_opened_event() const {
-  return (_event);
+  return _event;
 }
 
 /**

--- a/bam/src/configuration/reader_v2.cc
+++ b/bam/src/configuration/reader_v2.cc
@@ -145,9 +145,8 @@ void reader_v2::_load(state::kpis& kpis) {
 
         // KPI state.
         if (!res.value_is_null(17)) {
-          kpi_event e(kpi_id, res.value_as_u32(4));
+          kpi_event e(kpi_id, res.value_as_u32(4), res.value_as_u64(17));
           e.status = res.value_as_i32(8);
-          e.start_time = res.value_as_u64(17);
           e.in_downtime = res.value_as_bool(18);
           e.impact_level = res.value_is_null(19) ? -1 : res.value_as_f64(19);
           kpis[kpi_id].set_opened_event(e);
@@ -206,17 +205,18 @@ void reader_v2::_load(state::kpis& kpis) {
  *                       description.
  */
 void reader_v2::_load(state::bas& bas, bam::ba_svc_mapping& mapping) {
+  log_v2::bam()->info("BAM: loading BAs");
   try {
     {
       std::string query(
           fmt::format("SELECT b.ba_id, b.name, b.state_source, b.level_w,"
-                      "       b.level_c, b.last_state_change, b.current_status,"
-                      "       b.in_downtime, b.inherit_kpi_downtimes"
-                      "  FROM mod_bam AS b"
-                      "  INNER JOIN mod_bam_poller_relations AS pr"
-                      "    ON b.ba_id=pr.ba_id"
-                      "  WHERE b.activate='1'"
-                      "    AND pr.poller_id={}",
+                      " b.level_c, b.last_state_change, b.current_status,"
+                      " b.in_downtime, b.inherit_kpi_downtimes"
+                      " FROM mod_bam AS b"
+                      " INNER JOIN mod_bam_poller_relations AS pr"
+                      " ON b.ba_id=pr.ba_id"
+                      " WHERE b.activate='1'"
+                      " AND pr.poller_id={}",
                       config::applier::state::instance().poller_id()));
       std::promise<database::mysql_result> promise;
       log_v2::bam()->trace("reader_v2 query: {}", query);
@@ -243,6 +243,9 @@ void reader_v2::_load(state::bas& bas, bam::ba_svc_mapping& mapping) {
             e.status = res.value_as_i32(6);
             e.in_downtime = res.value_as_bool(7);
             bas[ba_id].set_opened_event(e);
+            log_v2::bam()->trace(
+                "BAM: ba {} configuration (start_time:{}, in downtime: {})",
+                ba_id, e.start_time, e.in_downtime);
           }
         }
       } catch (std::exception const& e) {

--- a/bam/src/kpi.cc
+++ b/bam/src/kpi.cc
@@ -62,9 +62,9 @@ timestamp kpi::get_last_state_change() const {
  *
  *  @param[in] e  The kpi event.
  */
-void kpi::set_initial_event(kpi_event const& e) {
+void kpi::set_initial_event(const kpi_event& e) {
   if (!_event) {
-    _event.reset(new kpi_event(e));
+    _event = std::make_shared<kpi_event>(e);
     impact_values impacts;
     impact_hard(impacts);
     double new_impact_level =
@@ -74,10 +74,10 @@ void kpi::set_initial_event(kpi_event const& e) {
     if (new_impact_level != _event->impact_level &&
         _event->impact_level != -1) {
       time_t now = ::time(nullptr);
-      std::shared_ptr<kpi_event> new_event(new kpi_event(e));
+      std::shared_ptr<kpi_event> new_event = std::make_shared<kpi_event>(e);
       new_event->end_time = now;
       _initial_events.push_back(new_event);
-      new_event = std::shared_ptr<kpi_event>(new kpi_event(e));
+      new_event = std::make_shared<kpi_event>(e);
       new_event->start_time = now;
       _initial_events.push_back(new_event);
       _event = new_event;
@@ -102,7 +102,7 @@ void kpi::commit_initial_events(io::stream* visitor) {
              it(_initial_events.begin()),
          end(_initial_events.end());
          it != end; ++it)
-      visitor->write(std::shared_ptr<io::data>(new kpi_event(**it)));
+      visitor->write(std::make_shared<kpi_event>(**it));
   }
   _initial_events.clear();
 }

--- a/bam/src/kpi_ba.cc
+++ b/bam/src/kpi_ba.cc
@@ -258,17 +258,14 @@ void kpi_ba::_open_new_event(io::stream* visitor,
                              int impact,
                              kpi_ba::state ba_state,
                              timestamp event_start_time) {
-  _event = std::make_shared<kpi_event>(_id, _ba_id);
+  _event = std::make_shared<kpi_event>(_id, _ba_id, event_start_time);
   _event->impact_level = impact;
   _event->in_downtime = _ba->get_in_downtime();
   _event->output = _ba->get_output();
   _event->perfdata = _ba->get_perfdata();
-  _event->start_time = event_start_time;
   _event->status = ba_state;
-  if (visitor) {
-    std::shared_ptr<io::data> ke(new kpi_event(*_event));
-    visitor->write(ke);
-  }
+  if (visitor)
+    visitor->write(std::make_shared<kpi_event>(*_event));
 }
 
 /**

--- a/bam/src/kpi_boolexp.cc
+++ b/bam/src/kpi_boolexp.cc
@@ -195,12 +195,11 @@ void kpi_boolexp::_fill_impact(impact_values& impact) {
 void kpi_boolexp::_open_new_event(io::stream* visitor,
                                   int impact,
                                   kpi_boolexp::state state) {
-  _event = std::make_shared<kpi_event>(_id, _ba_id);
+  _event = std::make_shared<kpi_event>(_id, _ba_id, ::time(nullptr));
   _event->impact_level = impact;
   _event->in_downtime = false;
   _event->output = "BAM boolean expression computed by Centreon Broker";
   _event->perfdata = "";
-  _event->start_time = time(nullptr);
   _event->status = state;
   if (visitor) {
     visitor->write(_event);

--- a/bam/src/kpi_event.cc
+++ b/bam/src/kpi_event.cc
@@ -26,11 +26,12 @@ using namespace com::centreon::broker::bam;
 /**
  *  Constructor.
  */
-kpi_event::kpi_event(uint32_t kpi_id, uint32_t ba_id)
+kpi_event::kpi_event(uint32_t kpi_id, uint32_t ba_id, time_t start_time)
     : io::data(kpi_event::static_type()),
       kpi_id(kpi_id),
       impact_level(0),
       in_downtime(false),
+      start_time(start_time),
       status(kpi_event::state::state_unknown),
       ba_id(ba_id) {}
 
@@ -111,7 +112,7 @@ mapping::entry const kpi_event::entries[] = {
 
 // Operations.
 static io::data* new_kpi_event() {
-  return new kpi_event(0, 0);
+  return new kpi_event(0, 0, 0);
 }
 
 io::event_info::event_operations const kpi_event::operations = {&new_kpi_event};

--- a/bam/src/main.cc
+++ b/bam/src/main.cc
@@ -139,6 +139,5 @@ void broker_module_init(void const* arg) {
                                                   "inherited_downtime");
     }
   }
-  return;
 }
 }

--- a/bam/src/monitoring_stream.cc
+++ b/bam/src/monitoring_stream.cc
@@ -201,7 +201,7 @@ int monitoring_stream::write(std::shared_ptr<io::data> const& data) {
       std::shared_ptr<neb::service_status> ss(
           std::static_pointer_cast<neb::service_status>(data));
       log_v2::bam()->trace(
-          "BAM: processing service status (host {}, service {}, hard state {}, "
+          "BAM: processing service status (host: {}, service: {}, hard state {}, "
           "current state {})",
           ss->host_id, ss->service_id, ss->last_hard_state, ss->current_state);
       multiplexing::publisher pblshr;
@@ -245,10 +245,10 @@ int monitoring_stream::write(std::shared_ptr<io::data> const& data) {
     case bam::ba_status::static_type(): {
       ba_status* status(static_cast<ba_status*>(data.get()));
       log_v2::bam()->trace(
-          "BAM: processing BA status (id {}, level {}, acknowledgement {}, "
-          "downtime {})",
+          "BAM: processing BA status (id {}, nominal {}, acknowledgement {}, "
+          "downtime {}) - in downtime {}",
           status->ba_id, status->level_nominal, status->level_acknowledgement,
-          status->level_downtime);
+          status->level_downtime, status->in_downtime);
       _ba_update.bind_value_as_f64(0, status->level_nominal);
       _ba_update.bind_value_as_f64(1, status->level_acknowledgement);
       _ba_update.bind_value_as_f64(2, status->level_downtime);
@@ -337,12 +337,6 @@ int monitoring_stream::write(std::shared_ptr<io::data> const& data) {
   // Event acknowledgement.
   return 0;
 }
-
-/**************************************
- *                                     *
- *           Private Methods           *
- *                                     *
- **************************************/
 
 /**
  *  Prepare queries.

--- a/bam/src/reporting_stream.cc
+++ b/bam/src/reporting_stream.cc
@@ -148,11 +148,13 @@ int32_t reporting_stream::stop() {
  *  @return Number of events acknowledged.
  */
 int reporting_stream::write(std::shared_ptr<io::data> const& data) {
-  log_v2::bam()->trace("BAM: reporting stream write");
   // Take this event into account.
   ++_pending_events;
   if (!validate(data, "BAM-BI"))
     return 0;
+
+  log_v2::bam()->trace("BAM: reporting stream write - event of type {:x}",
+                       data->type());
 
   switch (data->type()) {
     case io::events::data_type<io::events::bam, bam::de_kpi_event>::value:
@@ -191,11 +193,13 @@ int reporting_stream::write(std::shared_ptr<io::data> const& data) {
       _process_rebuild(data);
       break;
     default:
+      log_v2::bam()->trace("BAM: nothing to do with event of type {:x}",
+                           data->type());
       break;
   }
 
   // Event acknowledgement.
-  int retval(_ack_events);
+  int retval = _ack_events;
   _ack_events = 0;
   return retval;
 }
@@ -250,8 +254,8 @@ void reporting_stream::_apply(dimension_timeperiod_exclusion const& tpe) {
     timeperiod->add_excluded(excluded_tp);
   else
     log_v2::bam()->error(
-        "BAM-BI: could not apply exclusion of timeperiod {} by timeperiod {}: "
-        "at least one of the timeperiod does not exist",
+        "BAM-BI: could not apply exclusion of timeperiod {} by timeperiod {}"
+        ": at least one of the timeperiod does not exist",
         tpe.excluded_timeperiod_id, tpe.timeperiod_id);
 }
 
@@ -292,16 +296,13 @@ void reporting_stream::_close_inconsistent_events(char const* event_type,
   }
 
   // Close each event.
-  for (std::list<std::pair<uint32_t, time_t>>::const_iterator
-           it(events.begin()),
-       end(events.end());
-       it != end; ++it) {
+  for (auto& p : events) {
     time_t end_time;
     {
       std::string query_str(
           fmt::format("SELECT start_time FROM {} WHERE {}={} AND start_time>{} "
                       "ORDER BY start_time ASC LIMIT 1",
-                      table, id, it->first, it->second));
+                      table, id, p.first, p.second));
       log_v2::bam()->trace("reporting_stream: query: '{}'", query_str);
       std::promise<mysql_result> promise;
       _mysql.run_query_and_get_result(query_str, &promise);
@@ -316,13 +317,13 @@ void reporting_stream::_close_inconsistent_events(char const* event_type,
             "BAM-BI: could not get end time of inconsistent event of {} {} "
             "starting"
             " at {} : {}",
-            event_type, it->first, it->second, e.what());
+            event_type, p.first, p.second, e.what());
       }
     }
     {
       std::string query(
           fmt::format("UPDATE {} SET end_time={} WHERE {}={} AND start_time={}",
-                      table, end_time, id, it->first, it->second));
+                      table, end_time, id, p.first, p.second));
       log_v2::bam()->trace("reporting_stream: query: '{}'", query);
       _mysql.run_query(query, database::mysql_error::close_event, true);
     }
@@ -1294,13 +1295,14 @@ void reporting_stream::_compute_event_durations(
   }
 
   for (std::vector<std::pair<time::timeperiod::ptr, bool>>::const_iterator
-           it(timeperiods.begin()),
-       end(timeperiods.end());
+           it = timeperiods.begin(),
+           end = timeperiods.end();
        it != end; ++it) {
     time::timeperiod::ptr tp = it->first;
     bool is_default = it->second;
 
-    std::shared_ptr<ba_duration_event> dur_ev(new ba_duration_event);
+    std::shared_ptr<ba_duration_event> dur_ev{
+        std::make_shared<ba_duration_event>()};
     dur_ev->ba_id = ev->ba_id;
     dur_ev->real_start_time = ev->start_time;
     dur_ev->start_time = tp->get_next_valid(ev->start_time);

--- a/bam/src/service_book.cc
+++ b/bam/src/service_book.cc
@@ -19,6 +19,7 @@
 #include "com/centreon/broker/bam/service_book.hh"
 
 #include "com/centreon/broker/bam/service_listener.hh"
+#include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/neb/acknowledgement.hh"
 #include "com/centreon/broker/neb/downtime.hh"
 #include "com/centreon/broker/neb/service_status.hh"
@@ -35,6 +36,8 @@ using namespace com::centreon::broker::bam;
 void service_book::listen(uint32_t host_id,
                           uint32_t service_id,
                           service_listener* listnr) {
+  log_v2::bam()->trace("BAM: service ({}, {}) added to service book", host_id,
+                       service_id);
   _book.insert(std::make_pair(std::make_pair(host_id, service_id), listnr));
 }
 

--- a/bam/test/ba/kpi_ba.cc
+++ b/bam/test/ba/kpi_ba.cc
@@ -259,6 +259,7 @@ TEST_F(KpiBA, KpiBaDt) {
   dt->host_id = 3;
   dt->service_id = 1;
   dt->entry_time = now + 12;
+  dt->actual_start_time = now + 12;
   dt->was_started = true;
   kpis[0]->service_update(dt, _visitor.get());
 

--- a/bam/test/ba/kpi_service.cc
+++ b/bam/test/ba/kpi_service.cc
@@ -507,6 +507,7 @@ TEST_F(BamBA, KpiServiceDtInheritAllCritical) {
     dt->host_id = ss->host_id;
     dt->service_id = 1;
     dt->was_started = true;
+    dt->actual_start_time = now + 2;
     dt->actual_end_time = 0;
     kpis[j]->service_update(dt, _visitor.get());
 
@@ -565,6 +566,7 @@ TEST_F(BamBA, KpiServiceDtInheritOneOK) {
     dt->host_id = ss->host_id;
     dt->service_id = 1;
     dt->was_started = true;
+    dt->actual_start_time = now + 2;
     dt->actual_end_time = 0;
     kpis[j]->service_update(dt, _visitor.get());
 
@@ -574,8 +576,8 @@ TEST_F(BamBA, KpiServiceDtInheritOneOK) {
   }
 
   auto events = _visitor->queue();
-  ASSERT_EQ(events.size(), 5u);
   _visitor->print_events();
+  ASSERT_EQ(events.size(), 13u);
 }
 
 TEST_F(BamBA, KpiServiceIgnoreDt) {
@@ -619,6 +621,7 @@ TEST_F(BamBA, KpiServiceIgnoreDt) {
 
     dt->host_id = ss->host_id;
     dt->service_id = 1;
+    dt->actual_start_time = now + 2;
     dt->was_started = true;
     dt->actual_end_time = 0;
     kpis[j]->service_update(dt, _visitor.get());
@@ -670,6 +673,7 @@ TEST_F(BamBA, KpiServiceDtIgnoreKpi) {
 
     dt->host_id = ss->host_id;
     dt->service_id = 1;
+    dt->actual_start_time = now + 2;
     dt->was_started = true;
     dt->actual_end_time = 0;
     kpis[j]->service_update(dt, _visitor.get());
@@ -728,6 +732,7 @@ TEST_F(BamBA, KpiServiceDtIgnoreKpiImpact) {
 
     dt->host_id = ss->host_id;
     dt->service_id = 1;
+    dt->actual_start_time = now + 2;
     dt->was_started = true;
     dt->actual_end_time = 0;
     kpis[j]->service_update(dt, _visitor.get());
@@ -788,6 +793,7 @@ TEST_F(BamBA, KpiServiceDtIgnoreKpiBest) {
 
     dt->host_id = ss->host_id;
     dt->service_id = 1;
+    dt->actual_start_time = now + 2;
     dt->was_started = true;
     dt->actual_end_time = 0;
     kpis[j]->service_update(dt, _visitor.get());
@@ -849,6 +855,7 @@ TEST_F(BamBA, KpiServiceDtIgnoreKpiWorst) {
     dt->host_id = ss->host_id;
     dt->service_id = 1;
     dt->was_started = true;
+    dt->actual_start_time = now + 2;
     dt->actual_end_time = 0;
     kpis[j]->service_update(dt, _visitor.get());
 
@@ -899,6 +906,7 @@ TEST_F(BamBA, KpiServiceDtIgnoreKpiRatio) {
 
     dt->host_id = ss->host_id;
     dt->service_id = 1;
+    dt->actual_start_time = now + 2;
     dt->was_started = true;
     dt->actual_end_time = 0;
     kpis[j]->service_update(dt, _visitor.get());

--- a/bam/test/exp_builder/availability_builder.cc
+++ b/bam/test/exp_builder/availability_builder.cc
@@ -41,3 +41,24 @@ TEST(BamAvailabilityBuilder, Simple) {
   /* The availability here is the duration from start_time to end_time: 3300 */
   ASSERT_EQ(builder.get_available(), 3300);
 }
+
+//TEST(BamAvailabilityBuilder, SummerTime) {
+//  /* sun. 27 mars 2021 15:59:18 CEST */
+//  time_t end_time = 1616939958u;
+//  /* sun. 28 mars 2021 14:59:18 CEST */
+//  time_t start_time = 1616936358u;
+//
+//  time::timeperiod::ptr period{std::make_shared<time::timeperiod>(
+//      4, "test_timeperiod", "test_alias", "08:00-20:00", "08:00-20:00",
+//      "08:00-20:00", "08:00-20:00", "08:00-20:00", "08:00-20:00",
+//      "08:00-20:00")};
+//  ASSERT_TRUE(period->is_valid(end_time));
+//
+//  bam::availability_builder builder(end_time, start_time);
+//  ASSERT_EQ(builder.get_available(), 0);
+//
+//  builder.add_event(0, start_time, end_time, false, period);
+//
+//  /* The availability here is the duration from start_time to end_time: 3300 */
+//  ASSERT_EQ(builder.get_available(), 3600);
+//}

--- a/cmake.sh
+++ b/cmake.sh
@@ -239,12 +239,12 @@ if [ "$force" = "1" ] ; then
 fi
 cd build
 if [ $maj = "centos7" ] ; then
-    rm -rf ~/.conan/profiles/default
-    if [ "$CONAN_REBUILD" = "1" ] ; then
-      $conan install .. -s compiler.libcxx=libstdc++11 --build="*"
-    else
-      $conan install .. -s compiler.libcxx=libstdc++11 --build=missing
-    fi
+  rm -rf ~/.conan/profiles/default
+  if [ "$CONAN_REBUILD" = "1" ] ; then
+    $conan install .. -s compiler.libcxx=libstdc++11 --build="*"
+  else
+    $conan install .. -s compiler.libcxx=libstdc++11 --build=missing
+  fi
 else
     $conan install .. -s compiler.libcxx=libstdc++11 --build=missing
 fi

--- a/core/inc/com/centreon/broker/bbdo/version_response.hh
+++ b/core/inc/com/centreon/broker/bbdo/version_response.hh
@@ -47,9 +47,9 @@ class version_response : public io::data {
 
   version_response();
   version_response(const std::string& extensions);
-  version_response(const version_response &) = delete;
+  version_response(const version_response&) = delete;
   ~version_response() noexcept = default;
-  version_response& operator=(const version_response & ) = delete;
+  version_response& operator=(const version_response&) = delete;
 
   /**
    *  Get the event type.

--- a/core/inc/com/centreon/broker/io/extension.hh
+++ b/core/inc/com/centreon/broker/io/extension.hh
@@ -34,54 +34,60 @@ namespace io {
  *
  */
 class extension {
-    std::string _name;
-    bool _optional;
-    bool _mandatory;
-    std::unordered_map<std::string, std::string> _options;
+  std::string _name;
+  bool _optional;
+  bool _mandatory;
+  std::unordered_map<std::string, std::string> _options;
 
-  public:
-    extension() : _optional{false}, _mandatory{false} {}
+ public:
+  extension() : _optional{false}, _mandatory{false} {}
 
-    extension(const std::string& name, bool optional, bool mandatory) :
-      _name{name},
-      _optional{optional},
-      _mandatory{mandatory} {}
+  extension(const std::string& name, bool optional, bool mandatory)
+      : _name{name}, _optional{optional}, _mandatory{mandatory} {}
 
-    extension(const extension& other) : _name{other._name}, _optional{other._optional}, _mandatory{other._mandatory}, _options{other._options} {}
+  extension(const extension& other)
+      : _name{other._name},
+        _optional{other._optional},
+        _mandatory{other._mandatory},
+        _options{other._options} {}
 
-    extension(extension&& other) : _name{std::move(other._name)}, _optional{other._optional}, _mandatory{other._mandatory}, _options{std::move(other._options)} {}
+  extension(extension&& other)
+      : _name{std::move(other._name)},
+        _optional{other._optional},
+        _mandatory{other._mandatory},
+        _options{std::move(other._options)} {}
 
-    extension& operator=(extension&& ext) {
-      if (&ext != this) {
-        _name = std::move(ext._name);
-        _optional = ext._optional;
-        _mandatory = ext._mandatory;
-        _options = std::move(ext._options);
-      }
-      return *this;
+  extension& operator=(extension&& ext) {
+    if (&ext != this) {
+      _name = std::move(ext._name);
+      _optional = ext._optional;
+      _mandatory = ext._mandatory;
+      _options = std::move(ext._options);
     }
+    return *this;
+  }
 
-    extension& operator=(const extension& ext) {
-      if (&ext != this) {
-        _name = ext._name;
-        _optional = ext._optional;
-        _mandatory = ext._mandatory;
-        _options = ext._options;
-      }
-      return *this;
+  extension& operator=(const extension& ext) {
+    if (&ext != this) {
+      _name = ext._name;
+      _optional = ext._optional;
+      _mandatory = ext._mandatory;
+      _options = ext._options;
     }
+    return *this;
+  }
 
-    std::unordered_map<std::string, std::string>& mutable_options() {
-      return _options;
-    }
-    const std::unordered_map<std::string, std::string>& options() const {
-      return _options;
-    }
-    const std::string& name() const { return _name; }
-    bool is_optional() const { return _optional; }
-    bool is_mandatory() const { return _mandatory; }
+  std::unordered_map<std::string, std::string>& mutable_options() {
+    return _options;
+  }
+  const std::unordered_map<std::string, std::string>& options() const {
+    return _options;
+  }
+  const std::string& name() const { return _name; }
+  bool is_optional() const { return _optional; }
+  bool is_mandatory() const { return _mandatory; }
 };
-}
+}  // namespace io
 
 CCB_END()
 #endif /* !CCB_IO_EXTENSION_HH */

--- a/core/test/test_server.cc
+++ b/core/test/test_server.cc
@@ -76,7 +76,7 @@ void test_server::run() {
     _bind_ok = false;
     std::unique_lock<std::mutex> lock(_m_init);
     _initialised = true;
-    _m_init.unlock();
+    lock.unlock();
     _cond_init.notify_all();
     return;
   }

--- a/notification/src/stream.cc
+++ b/notification/src/stream.cc
@@ -392,7 +392,7 @@ void stream::_process_service_status_event(neb::service_status const& event) {
     std::unique_ptr<QWriteLocker> lock(_state.write_lock());
     node::ptr n = _state.get_node_by_id(id);
     if (!n)
-      throw msg_fmt("notification: got an unknown service id: {}, host id: {}",
+      throw msg_fmt("notification: got an unknown service: {}, host: {}",
                     id.get_service_id(), id.get_host_id());
 
     // Save the old state and copy the current state.
@@ -450,7 +450,7 @@ void stream::_process_host_status_event(neb::host_status const& event) {
     std::unique_ptr<QWriteLocker> lock(_state.write_lock());
     node::ptr n = _state.get_node_by_id(id);
     if (!n)
-      throw msg_fmt("notification: got an unknown host id: {}",
+      throw msg_fmt("notification: got an unknown host: {}",
                     id.get_host_id());
 
     // Save the old state and copy the current state.

--- a/sql/src/stream.cc
+++ b/sql/src/stream.cc
@@ -169,5 +169,5 @@ int32_t stream::write(std::shared_ptr<io::data> const& data) {
 void stream::statistics(nlohmann::json& tree) const {
   nlohmann::json obj{storage::conflict_manager::instance().get_statistics()};
   tree["sql pending events"] = _pending_events;
-  tree["conflict_manager"] = obj;
+  tree["conflict_manager"] = obj[0];
 }

--- a/storage/src/conflict_manager_sql.cc
+++ b/storage/src/conflict_manager_sql.cc
@@ -943,7 +943,7 @@ void conflict_manager::_process_host(
 
   // Log message.
   log_v2::sql()->debug(
-      "SQL: processing host event (poller: {}, id: {}, name: {})", h.poller_id,
+      "SQL: processing host event (poller: {}, host: {}, name: {})", h.poller_id,
       h.host_id, h.host_name);
 
   // Processing
@@ -1066,7 +1066,7 @@ void conflict_manager::_process_host_status(
       !hs.next_check) {                 // - initial state
     // Apply to DB.
     log_v2::sql()->info(
-        "processing host status event (id: {}, last check: {}, state ({}, {}))",
+        "processing host status event (host: {}, last check: {}, state ({}, {}))",
         hs.host_id, hs.last_check, hs.current_state, hs.state_type);
 
     // Prepare queries.
@@ -1577,7 +1577,7 @@ void conflict_manager::_process_service(
 
     // Log message.
     log_v2::sql()->info(
-        "SQL: processing service event (host id: {}, service id: {}, "
+        "SQL: processing service event (host: {}, service: {}, "
         "description: {})",
         s.host_id, s.service_id, s.service_description);
 

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -131,7 +131,6 @@ tcp_connection::pointer tcp_async::get_connection(
     auto retval = f.get();
     if (retval)
       return retval;
-    auto now = std::chrono::system_clock::now();
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   } while (std::chrono::system_clock::now() < end);
 


### PR DESCRIPTION
## Description

New BA with new KPI have their start time badly initialized. This patch fixes this issue.

REFS: MON-7405

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
