### PR TITLE
fix(ci):quality gate timeout management

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 /*
 ** Variables.
 */
@@ -83,14 +85,36 @@ try {
 
   // sonarQube step to get qualityGate result
   stage('Quality gate') {
-    timeout(time: 10, unit: 'MINUTES') {
-      def qualityGate = waitForQualityGate()
-      if (qualityGate.status != 'OK') {
-        currentBuild.result = 'FAIL'
+    node {
+      def reportFilePath = "target/sonar/report-task.txt"
+      def reportTaskFileExists = fileExists "${reportFilePath}"
+      if (reportTaskFileExists) {
+        echo "Found report task file"
+        def taskProps = readProperties file: "${reportFilePath}"
+        echo "taskId[${taskProps['ceTaskId']}]"
+        timeout(time: 10, unit: 'MINUTES') {
+          while (true) {
+            sleep 5
+            def taskStatusResult    =
+              sh(returnStdout: true, script: "curl -s -X GET -u ${authString} \'${sonarProps['sonar.host.url']}/api/ce/task?id=${taskProps['ceTaskId']}\'")
+              echo "taskStatusResult[${taskStatusResult}]"
+              def taskStatus  = new JsonSlurper().parseText(taskStatusResult).task.status
+              echo "taskStatus[${taskStatus}]"
+              // Status can be SUCCESS, ERROR, PENDING, or IN_PROGRESS. The last two indicate it's
+              // not done yet.
+              if (taskStatus != "IN_PROGRESS" && taskStatus != "PENDING") {
+                  break;
+              }
+              def qualityGate = waitForQualityGate()
+              if (qualityGate.status != 'OK') {
+                currentBuild.result = 'FAIL'
+              }
+          }
+        }
       }
-    }
-    if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
-      error('Quality gate failure: ${qualityGate.status}.');
+      if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
+        error('Quality gate failure: ${qualityGate.status}.');
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Retrieve quality gate status with sonar api and listening to the coming webhook in order to avoid ten minutes timeout.


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)


## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
