### PR TITLE
Mon 10682 engine segfault 20.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Bug fix
 
+*cbmod*
+
+A link issue in cbmod caused a crash in centengine. This new version fixes it.
+
 *SQL*
 
 Broker stores its connections to the database in an array. Once they are

--- a/lua/test/lua.cc
+++ b/lua/test/lua.cc
@@ -271,7 +271,7 @@ TEST_F(LuaTest, SocketCreation) {
                "end\n\n"
                "function write(d)\n"
                "end\n\n");
-  luabinding* bind;
+  luabinding* bind = nullptr;
   ASSERT_NO_THROW(bind = new luabinding(filename, conf, *_cache));
   delete bind;
   RemoveFile(filename);

--- a/neb/CMakeLists.txt
+++ b/neb/CMakeLists.txt
@@ -225,9 +225,9 @@ set_property(TARGET "${CBMOD}"
 if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # Flags needed to include all symbols in shared library.
   target_link_libraries("${CBMOD}"
-    "-Wl,--whole-archive" "nebbase" "rokerbase" "-Wl,--no-whole-archive" ${fmt_LIBS} ${spdlog_LIBS} ${asio_LIBS} ${OpenSSL_LIBS})
+    "-Wl,--whole-archive" "rokerbase" "-Wl,--no-whole-archive" ${fmt_LIBS} ${spdlog_LIBS} ${asio_LIBS} ${OpenSSL_LIBS})
 else ()
-  target_link_libraries("${CBMOD}" "nebbase" "rokerbase" ${fmt_LIBS} ${spdlog_LIBS} ${asio_LIBS} ${OpenSSL_LIBS})
+  target_link_libraries("${CBMOD}" "rokerbase" ${fmt_LIBS} ${spdlog_LIBS} ${asio_LIBS} ${OpenSSL_LIBS})
 endif ()
 set_target_properties("${CBMOD}" PROPERTIES PREFIX "")
 

--- a/neb/src/neb.cc
+++ b/neb/src/neb.cc
@@ -41,12 +41,6 @@ using namespace com::centreon::broker;
 // Specify the event broker API version.
 NEB_API_VERSION(CURRENT_NEB_API_VERSION)
 
-/**************************************
- *                                     *
- *         Exported Functions          *
- *                                     *
- **************************************/
-
 extern "C" {
 /**
  *  @brief Module exit point.
@@ -126,7 +120,8 @@ int nebmodule_init(int flags, char const* args, void* handle) {
     setlocale(LC_NUMERIC, "C");
 
     // Default logging object.
-    std::shared_ptr<neb::monitoring_logger> monlog{std::make_shared<neb::monitoring_logger>()};
+    std::shared_ptr<neb::monitoring_logger> monlog{
+        std::make_shared<neb::monitoring_logger>()};
 
     try {
       // Default logging object.
@@ -170,11 +165,15 @@ int nebmodule_init(int flags, char const* args, void* handle) {
           s.loggers());
 
       std::string err;
-      if (!log_v2::instance().load("/etc/centreon-broker/log-config.json", s.broker_name(), err))
+      if (!log_v2::instance().load("/etc/centreon-broker/log-config.json",
+                                   s.broker_name(), err))
         logging::error(logging::low) << err;
 
       // Remove monitoring log.
       logging::manager::instance().log_on(monlog, 0);
+
+      com::centreon::broker::config::applier::state::instance().apply(s);
+
     } catch (std::exception const& e) {
       logging::error(logging::high) << e.what();
       logging::manager::instance().log_on(monlog, 0);

--- a/neb/src/service_status.cc
+++ b/neb/src/service_status.cc
@@ -23,12 +23,6 @@
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::neb;
 
-/**************************************
- *                                     *
- *            Public Methods           *
- *                                     *
- **************************************/
-
 /**
  *  @brief Default constructor.
  *
@@ -76,12 +70,6 @@ service_status& service_status::operator=(service_status const& ss) {
   return *this;
 }
 
-/**************************************
- *                                     *
- *           Private Methods           *
- *                                     *
- **************************************/
-
 /**
  *  @brief Copy internal members of the given object to the current
  *         instance.
@@ -101,12 +89,6 @@ void service_status::_internal_copy(service_status const& ss) {
   service_description = ss.service_description;
   service_id = ss.service_id;
 }
-
-/**************************************
- *                                     *
- *           Static Objects            *
- *                                     *
- **************************************/
 
 // Mapping.
 mapping::entry const service_status::entries[] = {


### PR DESCRIPTION
## Description

A link issue in cbmod creates segfault in centengine.
This patch fixes this issue.

REFS: MON-10682

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
