### PR TITLE
fix(sql): Before executing a bulk of queries, we check db connection

### DIFF
--- a/core/inc/com/centreon/broker/mysql.hh
+++ b/core/inc/com/centreon/broker/mysql.hh
@@ -18,9 +18,6 @@
 #ifndef CCB_MYSQL_HH
 #define CCB_MYSQL_HH
 
-#include <atomic>
-
-#include "com/centreon/broker/database/mysql_error.hh"
 #include "com/centreon/broker/mysql_connection.hh"
 
 CCB_BEGIN()

--- a/core/inc/com/centreon/broker/mysql_connection.hh
+++ b/core/inc/com/centreon/broker/mysql_connection.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2018 Centreon
+** Copyright 2018 - 2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 #ifndef CCB_MYSQL_CONNECTION_HH
 #define CCB_MYSQL_CONNECTION_HH
 
-#include <atomic>
 #include <condition_variable>
 #include <future>
 #include <list>
@@ -70,8 +69,6 @@ class mysql_connection {
   mutable std::mutex _tasks_m;
   std::condition_variable _tasks_condition;
   std::atomic<bool> _finish_asked;
-  std::atomic<bool> _ping_asked;
-  std::promise<bool> _ping_promise;
   std::list<std::unique_ptr<database::mysql_task>> _tasks_list;
   std::atomic_int _local_tasks_count;
   bool _need_commit;
@@ -116,9 +113,13 @@ class mysql_connection {
   void _fetch_row_sync(database::mysql_task* task);
   void _push(std::unique_ptr<database::mysql_task>&& q);
   void _debug(MYSQL_BIND* bind, uint32_t size);
+  bool _try_to_reconnect();
 
   static void (mysql_connection::*const _task_processing_table[])(
       database::mysql_task* task);
+
+  void _prepare_connection();
+  void _clear_connection();
 
  public:
   /**************************************************************************/

--- a/core/src/mysql_manager.cc
+++ b/core/src/mysql_manager.cc
@@ -89,7 +89,7 @@ std::vector<std::shared_ptr<mysql_connection>> mysql_manager::get_connections(
     for (std::shared_ptr<mysql_connection> c : _connection) {
       // Is this thread matching what the configuration needs?
       if (c->match_config(db_cfg) && !c->is_finished() &&
-          !c->is_finish_asked() && !c->is_in_error() && c->ping()) {
+          !c->is_finish_asked() && !c->is_in_error()) {
         // Yes
         retval.push_back(c);
         ++current_connection;


### PR DESCRIPTION
## Description

This patch fixes the "MySQL server has gone away" we can see in the cbd logs.

REFS: MON-6917

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
