### PR TITLE
Mon 6917 dabase reconnect 20.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixes
 
+*sql*
+
+When a connection to the db is lost, we try to reestablish it. This change fixes
+an error "Mysql server has gone away" we often have in the BAM availabilities
+computations.
+
 *bbdo*
 
 When the connection of an acceptor is reversed, if cbd is stopped when there is

--- a/core/inc/com/centreon/broker/mysql.hh
+++ b/core/inc/com/centreon/broker/mysql.hh
@@ -18,9 +18,6 @@
 #ifndef CCB_MYSQL_HH
 #define CCB_MYSQL_HH
 
-#include <atomic>
-
-#include "com/centreon/broker/database/mysql_error.hh"
 #include "com/centreon/broker/mysql_connection.hh"
 
 CCB_BEGIN()

--- a/core/inc/com/centreon/broker/mysql_connection.hh
+++ b/core/inc/com/centreon/broker/mysql_connection.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2018 Centreon
+** Copyright 2018 - 2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 #ifndef CCB_MYSQL_CONNECTION_HH
 #define CCB_MYSQL_CONNECTION_HH
 
-#include <atomic>
 #include <condition_variable>
 #include <future>
 #include <list>
@@ -70,8 +69,6 @@ class mysql_connection {
   mutable std::mutex _tasks_m;
   std::condition_variable _tasks_condition;
   std::atomic<bool> _finish_asked;
-  std::atomic<bool> _ping_asked;
-  std::promise<bool> _ping_promise;
   std::list<std::unique_ptr<database::mysql_task>> _tasks_list;
   std::atomic_int _local_tasks_count;
   bool _need_commit;
@@ -115,9 +112,13 @@ class mysql_connection {
   void _fetch_row_sync(database::mysql_task* task);
   void _push(std::unique_ptr<database::mysql_task>&& q);
   void _debug(MYSQL_BIND* bind, uint32_t size);
+  bool _try_to_reconnect();
 
   static void (mysql_connection::*const _task_processing_table[])(
       database::mysql_task* task);
+
+  void _prepare_connection();
+  void _clear_connection();
 
  public:
   /**************************************************************************/

--- a/core/src/mysql_connection.cc
+++ b/core/src/mysql_connection.cc
@@ -71,6 +71,87 @@ bool mysql_connection::_server_error(int code) const {
   }
 }
 
+/**
+ * @brief Once the connection established, we set several parameters, this is
+ * done by this function.
+ */
+void mysql_connection::_prepare_connection() {
+  mysql_set_character_set(_conn, "utf8mb4");
+
+  if (_qps > 1)
+    mysql_autocommit(_conn, 0);
+  else
+    mysql_autocommit(_conn, 1);
+}
+
+/**
+ * @brief Function executed to close correctly the MYSQL connection.
+ */
+void mysql_connection::_clear_connection() {
+  for (std::unordered_map<uint32_t, MYSQL_STMT*>::iterator it = _stmt.begin(),
+                                                           end = _stmt.end();
+       it != end; ++it) {
+    mysql_stmt_close(it->second);
+    it->second = nullptr;
+  }
+  _stmt.clear();
+  mysql_close(_conn);
+}
+
+/**
+ * @brief Try to reconnect to the database when a server error arised.
+ *
+ * @return True on success, false otherwise.
+ */
+bool mysql_connection::_try_to_reconnect() {
+  std::lock_guard<std::mutex> lck(_start_m);
+
+  _clear_connection();
+  log_v2::sql()->info(
+      "mysql_connection: server has gone away, attempt to reconnect");
+  _conn = mysql_init(nullptr);
+  if (!_conn) {
+    log_v2::sql()->error("mysql_connection: reconnection failed.");
+    return false;
+  }
+
+  uint32_t timeout = 10;
+  mysql_options(_conn, MYSQL_OPT_CONNECT_TIMEOUT, &timeout);
+
+  const char* socket =
+      _host == "localhost" ? "/var/lib/mysql/mysql.sock" : nullptr;
+
+  if (!mysql_real_connect(_conn, _host.c_str(), _user.c_str(), _pwd.c_str(),
+                          _name.c_str(), _port, socket, CLIENT_FOUND_ROWS)) {
+    log_v2::sql()->error(
+        "mysql_connection: The mysql/mariadb database seems not started.");
+    return false;
+  }
+
+  _prepare_connection();
+
+  /* Re-prepare all statements */
+  bool fail = false;
+  for (auto itq = _stmt_query.begin(), endq = _stmt_query.end(); itq != endq;
+       ++itq) {
+    MYSQL_STMT* s = mysql_stmt_init(_conn);
+    if (!s) {
+      log_v2::sql()->error(
+          "mysql_connection: impossible to reset prepared statements");
+      fail = true;
+      break;
+    } else {
+      if (mysql_stmt_prepare(s, itq->second.c_str(), itq->second.size())) {
+        log_v2::sql()->error("mysql_connection: {}", mysql_stmt_error(s));
+        fail = true;
+        break;
+      } else
+        _stmt[itq->first] = s;
+    }
+  }
+  return !fail;
+}
+
 void mysql_connection::_query(mysql_task* t) {
   mysql_task_run* task(static_cast<mysql_task_run*>(t));
   log_v2::sql()->debug("mysql_connection: run query: {}", task->query);
@@ -203,7 +284,7 @@ void mysql_connection::_statement(mysql_task* t) {
   if (bb && mysql_stmt_bind_param(stmt, bb)) {
     std::string err_msg(::mysql_stmt_error(stmt));
     log_v2::sql()->error("mysql_connection: {}", err_msg);
-    if (task->fatal || _server_error(::mysql_stmt_errno(stmt)))
+    if (task->fatal)
       set_error_message(err_msg);
     else {
       logging::error(logging::medium)
@@ -225,7 +306,10 @@ void mysql_connection::_statement(mysql_task* t) {
             mysql_stmt_errno(stmt) != 1205)  // Dead Lock error
           attempts = MAX_ATTEMPTS;
 
-        mysql_commit(_conn);
+        if (mysql_commit(_conn)) {
+          set_error_message("Commit failed after execute statement");
+          break;
+        }
 
         log_v2::sql()->error("mysql_connection: {}", err_msg);
         logging::error(logging::medium) << "mysql_connection: " << err_msg;
@@ -236,7 +320,6 @@ void mysql_connection::_statement(mysql_task* t) {
           break;
         }
       } else {
-        //mysql_stmt_free_result(stmt);
         _need_commit = true;
         break;
       }
@@ -284,7 +367,10 @@ void mysql_connection::_statement_res(mysql_task* t) {
             mysql_stmt_errno(stmt) != 1205)  // Dead Lock error
           attempts = MAX_ATTEMPTS;
 
-        mysql_commit(_conn);
+        if (mysql_commit(_conn)) {
+          set_error_message("Commit failed after execute statement");
+          break;
+        }
 
         log_v2::sql()->error("mysql_connection: {}", err_msg);
         logging::error(logging::medium) << "mysql_connection: " << err_msg;
@@ -303,8 +389,6 @@ void mysql_connection::_statement_res(mysql_task* t) {
         if (prepare_meta_result == nullptr) {
           if (mysql_stmt_errno(stmt)) {
             std::string err_msg(::mysql_stmt_error(stmt));
-            if (_server_error(mysql_stmt_errno(stmt)))
-              set_error_message(err_msg);
             exceptions::msg e;
             e << err_msg;
             task->promise->set_exception(
@@ -317,8 +401,6 @@ void mysql_connection::_statement_res(mysql_task* t) {
 
           if (mysql_stmt_bind_result(stmt, bind->get_bind())) {
             std::string err_msg(::mysql_stmt_error(stmt));
-            if (_server_error(::mysql_stmt_errno(stmt)))
-              set_error_message(err_msg);
             exceptions::msg e;
             e << err_msg;
             task->promise->set_exception(
@@ -454,27 +536,6 @@ void mysql_connection::clear_error() {
   _error.clear();
 }
 
-/**
- * @brief This function checks if the connection to the database is still
- * active. It returns true in that case, false otherwise.
- *
- * @return a boolean.
- */
-bool mysql_connection::ping() {
-  if (_state == running) {
-    if (!_ping_asked) {
-      _ping_promise = std::promise<bool>();
-      {
-        std::lock_guard<std::mutex> lck(_tasks_m);
-        _ping_asked = true;
-        _tasks_condition.notify_all();
-      }
-    }
-    return _ping_promise.get_future().get();
-  } else
-    return false;
-}
-
 std::string mysql_connection::_get_stack() {
   std::string retval;
   for (auto& t : _tasks_list) {
@@ -553,12 +614,7 @@ void mysql_connection::_run() {
     _start_condition.notify_all();
     lck.unlock();
   } else {
-    mysql_set_character_set(_conn, "utf8mb4");
-
-    if (_qps > 1)
-      mysql_autocommit(_conn, 0);
-    else
-      mysql_autocommit(_conn, 1);
+    _prepare_connection();
 
     _state = running;
     _start_condition.notify_all();
@@ -573,23 +629,22 @@ void mysql_connection::_run() {
         assert(_tasks_list.empty());
       } else {
         _tasks_condition.wait(lock, [this] {
-          return _ping_asked || _finish_asked || !_tasks_list.empty();
+          return _finish_asked || !_tasks_list.empty();
         });
-        if (_ping_asked) {
-          int ret = mysql_ping(_conn);
-          if (ret) {
-            log_v2::sql()->warn(
-                "SQL: database ping failed: Server has gone away.");
-            _ping_promise.set_value(false);
-          } else
-            _ping_promise.set_value(true);
-          _ping_asked = false;
-        } else if (_tasks_list.empty()) {
+        if (_tasks_list.empty()) {
           _state = finished;
         }
         continue;
       }
       lock.unlock();
+
+        if (mysql_ping(_conn)) {
+          if (!_try_to_reconnect())
+            log_v2::sql()->error("SQL: Reconnection failed.");
+        }
+        else
+          log_v2::sql()->info("SQL: connection always alive");
+
       for (auto& task : tasks_list) {
         --_local_tasks_count;
         if (_task_processing_table[task->type])
@@ -601,14 +656,8 @@ void mysql_connection::_run() {
       }
       lock.lock();
     }
-    for (std::unordered_map<uint32_t, MYSQL_STMT*>::iterator it(_stmt.begin()),
-         end(_stmt.end());
-         it != end; ++it) {
-      mysql_stmt_close(it->second);
-      it->second = nullptr;
-    }
   }
-  mysql_close(_conn);
+  _clear_connection();
   mysql_thread_end();
 }
 
@@ -619,7 +668,6 @@ void mysql_connection::_run() {
 mysql_connection::mysql_connection(database_config const& db_cfg)
     : _conn(nullptr),
       _finish_asked(false),
-      _ping_asked(false),
       _local_tasks_count(0),
       _need_commit(false),
       _host(db_cfg.get_host()),

--- a/core/src/mysql_connection.cc
+++ b/core/src/mysql_connection.cc
@@ -638,12 +638,12 @@ void mysql_connection::_run() {
       }
       lock.unlock();
 
-        if (mysql_ping(_conn)) {
-          if (!_try_to_reconnect())
-            log_v2::sql()->error("SQL: Reconnection failed.");
-        }
-        else
-          log_v2::sql()->info("SQL: connection always alive");
+      if (mysql_ping(_conn)) {
+        if (!_try_to_reconnect())
+          log_v2::sql()->error("SQL: Reconnection failed.");
+      }
+      else
+        log_v2::sql()->trace("SQL: connection always alive");
 
       for (auto& task : tasks_list) {
         --_local_tasks_count;

--- a/core/src/mysql_manager.cc
+++ b/core/src/mysql_manager.cc
@@ -89,8 +89,8 @@ std::vector<std::shared_ptr<mysql_connection>> mysql_manager::get_connections(
     std::lock_guard<std::mutex> lock(_cfg_mutex);
     for (std::shared_ptr<mysql_connection> c : _connection) {
       // Is this thread matching what the configuration needs?
-      if (c->match_config(db_cfg) && !c->is_finished() && !c->is_finish_asked() && !c->is_in_error() &&
-          c->ping()) {
+      if (c->match_config(db_cfg) && !c->is_finished() &&
+          !c->is_finish_asked() && !c->is_in_error()) {
         // Yes
         retval.push_back(c);
         ++current_connection;


### PR DESCRIPTION
## Description

This patch fixes the "MySQL server has gone away" we can see in the cbd logs.

REFS: MON-6917

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)