### PR TITLE
Mon 6917 dabase reconnect 20.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixes
 
+*sql*
+
+When a connection to the db is lost, we try to reestablish it. This change fixes
+an error "Mysql server has gone away" we often have in the BAM availabilities
+computations.
+
 *bbdo*
 
 When the connection of an acceptor is reversed, if cbd is stopped when there is

--- a/core/src/mysql_connection.cc
+++ b/core/src/mysql_connection.cc
@@ -628,9 +628,8 @@ void mysql_connection::_run() {
         _local_tasks_count = tasks_list.size();
         assert(_tasks_list.empty());
       } else {
-        _tasks_condition.wait(lock, [this] {
-          return _finish_asked || !_tasks_list.empty();
-        });
+        _tasks_condition.wait(
+            lock, [this] { return _finish_asked || !_tasks_list.empty(); });
         if (_tasks_list.empty()) {
           _state = finished;
         }
@@ -638,12 +637,11 @@ void mysql_connection::_run() {
       }
       lock.unlock();
 
-        if (mysql_ping(_conn)) {
-          if (!_try_to_reconnect())
-            log_v2::sql()->error("SQL: Reconnection failed.");
-        }
-        else
-          log_v2::sql()->info("SQL: connection always alive");
+      if (mysql_ping(_conn)) {
+        if (!_try_to_reconnect())
+          log_v2::sql()->error("SQL: Reconnection failed.");
+      } else
+        log_v2::sql()->trace("SQL: connection always alive");
 
       for (auto& task : tasks_list) {
         --_local_tasks_count;


### PR DESCRIPTION
## Description

When a connection received from the DB server "mysql server has gone away", it tries to reconnect, this avoid many errors, paritularly those with bam availabilities computations.

REFS: MON-6917

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
