### PR TITLE
fix(processing): stop() calls must be protected by try/catch

### DIFF
--- a/core/src/processing/failover.cc
+++ b/core/src/processing/failover.cc
@@ -354,7 +354,12 @@ void failover::_run() {
       log_v2::core()->error("failover: global error: {}", e.what());
       {
         if (_stream) {
-          int32_t ack_events = _stream->stop();
+          int32_t ack_events;
+          try {
+            ack_events = _stream->stop();
+          } catch (const std::exception& e) {
+            log_v2::core()->error("Failed to send stop event to stream: {}", e.what());
+          }
           _subscriber->get_muxer().ack_events(ack_events);
           std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
           _stream.reset();
@@ -372,7 +377,12 @@ void failover::_run() {
           "developers",
           _name);
       {
-        int32_t ack_events = _stream->stop();
+        int32_t ack_events;
+        try {
+        ack_events = _stream->stop();
+        } catch (const std::exception& e) {
+          log_v2::core()->error("Failed to send stop event to stream: {}", e.what());
+        }
         _subscriber->get_muxer().ack_events(ack_events);
         std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
         _stream.reset();
@@ -389,7 +399,12 @@ void failover::_run() {
       std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
       if (_stream) {
         // If ack_events is not zero, then we will store data twice
-        int32_t ack_events = _stream->stop();
+        int32_t ack_events;
+        try {
+        ack_events = _stream->stop();
+        } catch (const std::exception& e) {
+          log_v2::core()->error("Failed to send stop event to stream: {}", e.what());
+        }
         _subscriber->get_muxer().ack_events(ack_events);
         _stream.reset();
       }

--- a/core/src/processing/feeder.cc
+++ b/core/src/processing/feeder.cc
@@ -218,7 +218,12 @@ void feeder::_callback() noexcept {
   /* We don't get back the return value of stop() because it has non sense,
    * the only interest in calling stop() is to send an acknowledgement to the
    * peer. */
-  _client->stop();
+  try {
+    _client->stop();
+  } catch (const std::exception& e) {
+    log_v2::core()->error("Failed to send stop event to client: {}", e.what());
+  }
+
   {
     misc::read_lock lock(_client_m);
     _client.reset();


### PR DESCRIPTION
## Description

Some try/catch forgotten around the strem::stop() method.

REFS: MON-10922

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
