### PR TITLE
Mon 10922 stop segfault 21.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ When a connection to the db is lost, we try to reestablish it. This change fixes
 a error "MySQL server has gone away" we often have in the BAM availabilities
 computations.
 
+*processing*
+
+When the stop event is sent by a peer, we must protect the call by try/catch to
+avoid an abortion that could appear.
+
 *bbdo*
 
 When the connection of an acceptor is reversed, if cbd is stopped when there is

--- a/core/src/processing/failover.cc
+++ b/core/src/processing/failover.cc
@@ -353,7 +353,12 @@ void failover::_run() {
       logging::error(logging::high) << e.what();
       {
         if (_stream) {
-          int32_t ack_events = _stream->stop();
+          int32_t ack_events;
+          try {
+            ack_events = _stream->stop();
+          } catch (const std::exception& e) {
+            log_v2::core()->error("Failed to send stop event to stream: {}", e.what());
+          }
           _subscriber->get_muxer().ack_events(ack_events);
           std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
           _stream.reset();
@@ -371,7 +376,12 @@ void failover::_run() {
           << "software bug that should be reported to Centreon Broker "
              "developers";
       {
-        int32_t ack_events = _stream->stop();
+        int32_t ack_events;
+        try {
+        ack_events = _stream->stop();
+        } catch (const std::exception& e) {
+          log_v2::core()->error("Failed to send stop event to stream: {}", e.what());
+        }
         _subscriber->get_muxer().ack_events(ack_events);
         std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
         _stream.reset();
@@ -388,7 +398,12 @@ void failover::_run() {
       std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
       if (_stream) {
         // If ack_events is not zero, then we will store data twice
-        int32_t ack_events = _stream->stop();
+        int32_t ack_events;
+        try {
+        ack_events = _stream->stop();
+        } catch (const std::exception& e) {
+          log_v2::core()->error("Failed to send stop event to stream: {}", e.what());
+        }
         _subscriber->get_muxer().ack_events(ack_events);
         _stream.reset();
       }

--- a/core/src/processing/feeder.cc
+++ b/core/src/processing/feeder.cc
@@ -225,7 +225,12 @@ void feeder::_callback() noexcept {
   /* We don't get back the return value of stop() because it has non sense,
    * the only interest in calling stop() is to send an acknowledgement to the
    * peer. */
-  _client->stop();
+  try {
+    _client->stop();
+  } catch (const std::exception& e) {
+    log_v2::core()->error("Failed to send stop event to client: {}", e.what());
+  }
+
   {
     misc::read_lock lock(_client_m);
     _client.reset();


### PR DESCRIPTION
## Description

Some try/catch forgotten around the strem::stop() method.

REFS: MON-10922

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
