### PR TITLE
enh(ci): New packaging workflow and more // jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ try {
       error('Package stage failure.');
     }
   }
-  ##FIXME : remove CI branches for delivery
+  #FIXME : remove CI branches for delivery
   if ((env.BUILD == 'RELEASE') || (env.BUILD == 'QA') || (env.BUILD == 'CI')) {
     stage('Delivery') {
       node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,14 @@ import groovy.json.JsonSlurper
 properties([buildDiscarder(logRotator(numToKeepStr: '50'))])
 def serie = '21.10'
 def maintenanceBranch = "${serie}.x"
+def qaBranch = "dev-${serie}"
+
 if (env.BRANCH_NAME.startsWith('release-')) {
   env.BUILD = 'RELEASE'
 } else if ((env.BRANCH_NAME == 'master') || (env.BRANCH_NAME == maintenanceBranch)) {
   env.BUILD = 'REFERENCE'
+} else if ((env.BRANCH_NAME == 'develop') || (env.BRANCH_NAME == qaBranch)) {
+  env.BUILD = 'QA'
 } else {
   env.BUILD = 'CI'
 }
@@ -128,7 +132,7 @@ try {
     }
   }
 
-  if ((env.BUILD == 'RELEASE') || (env.BUILD == 'REFERENCE')) {
+  if ((env.BUILD == 'RELEASE') || (env.BUILD == 'QA')) {
     stage('Delivery') {
       node {
         sh 'setup_centreon_build.sh'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,12 +104,14 @@ try {
       node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-package.sh centos7"
+        stash name: 'el7-rpms', includes: "output/x86_64/*.rpm"
       }
     },
     'centos8': {
       node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-package.sh centos8"
+        stash name: 'el8-rpms', includes: "output/x86_64/*.rpm"
       }
     },
     'debian10': {
@@ -133,6 +135,8 @@ try {
   if ((env.BUILD == 'RELEASE') || (env.BUILD == 'QA') || (env.BUILD == 'CI')) {
     stage('Delivery') {
       node("C++") {
+        unstash 'el7-rpms'
+        unstash 'el8-rpms'
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-delivery.sh"
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,8 +130,8 @@ try {
       error('Package stage failure.');
     }
   }
-
-  if ((env.BUILD == 'RELEASE') || (env.BUILD == 'QA')) {
+  ##FIXME : remove CI branches for delivery
+  if ((env.BUILD == 'RELEASE') || (env.BUILD == 'QA') || (env.BUILD == 'CI')) {
     stage('Delivery') {
       node {
         sh 'setup_centreon_build.sh'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ try {
         }
       }
     },
-    parallel 'packaging centos7': {
+    'packaging centos7': {
       node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-package.sh centos7"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 /*
 ** Variables.
 */
-properties([buildDiscarder(logRotator(numToKeepStr: '50'))])
+properties([buildDiscarder(logRotator(numToKeepStr: '10'))])
 def serie = '21.10'
 def maintenanceBranch = "${serie}.x"
 def qaBranch = "dev-${serie}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,3 @@
-import groovy.json.JsonSlurper
 
 /*
 ** Variables.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ stage('Source') {
 }
 
 try {
-  stage('Unit tests') {
+ /* stage('Unit tests') {
     parallel 'centos7': {
       node {
         sh 'setup_centreon_build.sh'
@@ -97,7 +97,7 @@ try {
         error('Quality gate failure: ${qualityGate.status}.');
       }
     }
-  }
+  }*/
 
   stage('Package') {
     parallel 'centos7': {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ if (env.BRANCH_NAME.startsWith('release-')) {
 ** Pipeline code.
 */
 stage('Source') {
-  node {
+  node("C++") {
     sh 'setup_centreon_build.sh'
     dir('centreon-broker') {
       checkout scm
@@ -36,7 +36,7 @@ stage('Source') {
 try {
  /* stage('Unit tests') {
     parallel 'centos7': {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-unittest.sh centos7"
         step([
@@ -54,7 +54,7 @@ try {
       }
     },
     'centos8': {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-unittest.sh centos8"
         step([
@@ -68,7 +68,7 @@ try {
       }
     },
     'debian10': {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-unittest.sh debian10"
         step([
@@ -88,7 +88,7 @@ try {
 
   // sonarQube step to get qualityGate result
   stage('Quality gate') {
-    node {
+    node("C++") {
       def qualityGate = waitForQualityGate()
       if (qualityGate.status != 'OK') {
         currentBuild.result = 'FAIL'
@@ -101,19 +101,19 @@ try {
 
   stage('Package') {
     parallel 'centos7': {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-package.sh centos7"
       }
     },
     'centos8': {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-package.sh centos8"
       }
     },
     'debian10': {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-package.sh debian10"
       }
@@ -132,7 +132,7 @@ try {
   }
   if ((env.BUILD == 'RELEASE') || (env.BUILD == 'QA') || (env.BUILD == 'CI')) {
     stage('Delivery') {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-delivery.sh"
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,6 @@ try {
       error('Package stage failure.');
     }
   }
-  #FIXME : remove CI branches for delivery
   if ((env.BUILD == 'RELEASE') || (env.BUILD == 'QA') || (env.BUILD == 'CI')) {
     stage('Delivery') {
       node {


### PR DESCRIPTION
## Description

Because of : 

- the new branch workflow
- the new packaging and rpm pushing workflow
- the necessity to give an easy access to rpm for the QA

Here's an enhancement that : 

- specify "QA" branches that are develop and dev-xx.yy.zz to manage the rpm pushing location 
- //lise build tests and packaging for all distributions
- push rpm directly on yum.centreon.com
It means that RPM created from develop and dev-xx.yy.zz branches are pushed directly to the unstable repo of yum.centreon.com and RPM created from release branches are pushed directly to the testing repo. 
No more RPM pushing for reference branches (for now) and PR- / CI branches

It speeds up the pipeline and the feedback loop for devs also.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Launch a job of each type of branches and check that everything is green on jenkins and that the packages are available on yum.centreon.com.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

