### PR TITLE
enh(ci): add rpms as jenkins artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,7 @@ try {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-package.sh centos7"
         stash name: 'el7-rpms', includes: "output/x86_64/*.rpm"
+        archiveArtifacts artifacts: "output/x86_64/*.rpm"
       }
     },
     'build centos8': {
@@ -79,6 +80,7 @@ try {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-package.sh centos8"
         stash name: 'el8-rpms', includes: "output/x86_64/*.rpm"
+        archiveArtifacts artifacts: "output/x86_64/*.rpm"
       }
     },
     'build debian10': {


### PR DESCRIPTION
## Description

For hotfixes or testing purpose, we need to retrieve rpm packages from Jenkins. Here's the enhancement doing it.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Launch jenkins job on this PR and retrieve this kind of view : 

![image](https://user-images.githubusercontent.com/83596451/131363190-7aa95b5b-d85f-45fd-9ad3-1aa3cc8dbd49.png)



## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

