### PR TITLE
fix(ci): removing output directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,7 @@ try {
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-package.sh centos7"
         stash name: 'el7-rpms', includes: "output/x86_64/*.rpm"
         archiveArtifacts artifacts: "output/x86_64/*.rpm"
+        sh 'rm -rf output'
       }
     },
     'build centos8': {
@@ -81,6 +82,7 @@ try {
         sh "./centreon-build/jobs/broker/${serie}/mon-broker-package.sh centos8"
         stash name: 'el8-rpms', includes: "output/x86_64/*.rpm"
         archiveArtifacts artifacts: "output/x86_64/*.rpm"
+        sh 'rm -rf output'
       }
     },
     'build debian10': {


### PR DESCRIPTION
## Description

Remove output rpm directory after stashing and archiving it because it could push twice the same rpms if it's not clean.


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check in the jenkins workspace that the output directory doesn't exist after the package stage

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

