### PR TITLE
fix(tcp): We add a keepalive on the acceptor side.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 21.04.4
 
+*tcp*
+
+A keepalive is added on the acceptor side.
+
 *rrd*
 
 New loop to check deleted index every 5 minutes and delete metric file associated.

--- a/tcp/src/tcp_async.cc
+++ b/tcp/src/tcp_async.cc
@@ -265,6 +265,9 @@ void tcp_async::handle_accept(std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
           ecc.message());
     else {
       std::time_t now = std::time(nullptr);
+      asio::ip::tcp::socket& sock = new_connection->socket();
+      asio::socket_base::keep_alive option{true};
+      sock.set_option(option);
       _strand.post([new_connection, now, acceptor, this] {
         _acceptor_available_con.insert(std::make_pair(
             acceptor.get(), std::make_pair(new_connection, now)));


### PR DESCRIPTION
## Description

For some configurations, when the connection is lost, the acceptor does not detect it. We add a keepalive to solve this point.

REFS: MON-11121

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

