### PR TITLE
fix(tcp): flush() function can get stuck.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 A keepalive is added on the acceptor side.
 
+The flush() method from tcp\_connection could get stuck in cases of retention.
+
 *rrd*
 
 New loop to check deleted index every 5 minutes and delete metric file associated.

--- a/tcp/src/tcp_connection.cc
+++ b/tcp/src/tcp_connection.cc
@@ -97,7 +97,7 @@ int32_t tcp_connection::flush() {
       throw exceptions::msg() << msg;
     }
   }
-  if (_write_queue_has_events && !_writing) {
+  if (!_writing) {
     _writing = true;
     // The strand is useful because of the flush() method.
     _strand.context().post(std::bind(&tcp_connection::writing, ptr()));


### PR DESCRIPTION
## Description

Fix in tcp_connection::flush()  to avoid lock.

REFS: MON-11163

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

