### PR TITLE
Mon 11163 flush hang 21.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 A keepalive is added on the acceptor side.
 
+The flush() method from tcp\_connection could get stuck in cases of retention.
+
 *rrd*
 
 New loop to check deleted index every 5 minutes and delete metric file associated.

--- a/core/inc/com/centreon/broker/bbdo/stream.hh
+++ b/core/inc/com/centreon/broker/bbdo/stream.hh
@@ -33,6 +33,22 @@ namespace bbdo {
  *  @brief BBDO stream.
  *
  *  The class converts data to NEB events back and forth.
+ *
+ *  It is a little tricky around acknowledgements.
+ *  This steam is able to read, to write and to flush.
+ *  
+ *  * write() serializes an event and writes it to the substream. It returns how many events can be acknowledged.
+ *    But this count is not directly accessible, it comes from the ack message sent by the peer. So we do not have
+ *    to count how many events are serialized, sometimes, we get an ack message and here is the value.
+ *  * read() gets some buffer from the substream and unserializes it to create an event. The internal buffer
+ *    is probably not empty after a call to read since buffers are not synchronous with events.
+ *
+ *
+ *  There are also three variables to manage acknowledgements:
+ *  * _events_received_since_last_ack: It is incremented each time a data is read. If this value is equal to
+ *    the _ack_limit, an ack message is sent to the peer and this value is reset to 0. When the peer receives
+ *    this ack message, it releases the corresponding events.
+ *  * _acknowledged_events: represents the number of events correctly received by the peer after calls to write().
  */
 class stream : public io::stream {
   class buffer {

--- a/core/src/bbdo/stream.cc
+++ b/core/src/bbdo/stream.cc
@@ -530,7 +530,7 @@ stream::stream(bool is_input,
       _negotiate{true},
       _negotiated{false},
       _timeout(5),
-      _acknowledged_events(0),
+      _acknowledged_events{0},
       _ack_limit(1000),
       _events_received_since_last_ack(0),
       _extensions{extensions} {}
@@ -842,9 +842,9 @@ bool stream::read(std::shared_ptr<io::data>& d, time_t deadline) {
     } else if ((event_id & 0xffff) == 2) {
       log_v2::bbdo()->info(
           "BBDO: received acknowledgement for {} events",
-          std::static_pointer_cast<ack const>(d)->acknowledged_events);
+          std::static_pointer_cast<const ack>(d)->acknowledged_events);
       acknowledge_events(
-          std::static_pointer_cast<ack const>(d)->acknowledged_events);
+          std::static_pointer_cast<const ack>(d)->acknowledged_events);
     } else if ((event_id & 0xffff) == 3) {
       log_v2::bbdo()->info("BBDO: received stop from peer");
       send_event_acknowledgement();
@@ -1149,7 +1149,7 @@ void stream::_write(std::shared_ptr<io::data> const& d) {
 int32_t stream::write(std::shared_ptr<io::data> const& d) {
   _write(d);
 
-  int32_t retval(_acknowledged_events);
+  int32_t retval = _acknowledged_events;
   _acknowledged_events -= retval;
   return retval;
 }

--- a/core/src/multiplexing/muxer.cc
+++ b/core/src/multiplexing/muxer.cc
@@ -205,7 +205,7 @@ void muxer::publish(std::shared_ptr<io::data> const event) {
  *  @return Respect io::stream::read()'s return value.
  */
 bool muxer::read(std::shared_ptr<io::data>& event, time_t deadline) {
-  bool timed_out(false);
+  bool timed_out{false};
   std::unique_lock<std::mutex> lock(_mutex);
 
   // No data is directly available.

--- a/core/test/multiplexing/muxer/read.cc
+++ b/core/test/multiplexing/muxer/read.cc
@@ -38,7 +38,7 @@ class MultiplexingMuxerRead : public ::testing::Test {
   void TearDown() override { config::applier::deinit(); }
 
   void setup(std::string const& name) {
-    _m.reset(new multiplexing::muxer(name, false));
+    _m = std::make_unique<multiplexing::muxer>(name, false);
     multiplexing::muxer::filters f;
     f.insert(io::raw::static_type());
     _m->set_read_filters(f);
@@ -46,8 +46,8 @@ class MultiplexingMuxerRead : public ::testing::Test {
   }
 
   void publish_events(int count = 10000) {
-    for (int i(0); i < count; ++i) {
-      std::shared_ptr<io::raw> r(new io::raw());
+    for (int i = 0; i < count; ++i) {
+      std::shared_ptr<io::raw> r{std::make_shared<io::raw>()};
       r->resize(sizeof(i));
       memcpy(r->data(), &i, sizeof(i));
       _m->publish(r);
@@ -56,7 +56,7 @@ class MultiplexingMuxerRead : public ::testing::Test {
 
   void reread_events(int from = 0, int to = 10000) {
     std::shared_ptr<io::data> d;
-    for (int i(from); i < to; ++i) {
+    for (int i = from; i < to; ++i) {
       d.reset();
       _m->read(d, 0);
       ASSERT_FALSE(!d);

--- a/tcp/src/tcp_connection.cc
+++ b/tcp/src/tcp_connection.cc
@@ -98,7 +98,7 @@ int32_t tcp_connection::flush() {
       throw msg_fmt(msg);
     }
   }
-  if (_write_queue_has_events && !_writing) {
+  if (!_writing) {
     _writing = true;
     // The strand is useful because of the flush() method.
     _strand.context().post(std::bind(&tcp_connection::writing, ptr()));


### PR DESCRIPTION
## Description

Fix in tcp_connectionn::flush() to solve a lock.

REFS: MON-11163

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

