### PR TITLE
Mon 11162 bam rrd 21.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 21.04.4
 
+*bbdo*
+
+If a broker receives bbdo message it cannot unserialize because of a missing
+module, it must be able to acknowledge it. Otherwise, this message is kept
+in retention by the peer and this can lead cbd instances to get stuck.
+
 *tcp*
 
 A keepalive is added on the acceptor side.

--- a/core/src/bbdo/stream.cc
+++ b/core/src/bbdo/stream.cc
@@ -859,7 +859,11 @@ bool stream::read(std::shared_ptr<io::data>& d, time_t deadline) {
     event_id = !d ? 0 : d->type();
   }
 
-  if (!timed_out && d)
+  /* If !timed_out, then we have two possibilities:
+   *  * we get an event d
+   *  * an event has been returned but we could not unserialize it.
+   */
+  if (!timed_out)
     ++_events_received_since_last_ack;
   if (_events_received_since_last_ack >= _ack_limit)
     send_event_acknowledgement();
@@ -995,9 +999,9 @@ bool stream::_read_any(std::shared_ptr<io::data>& d, time_t deadline) {
           log_v2::bbdo()->trace("unserialized {} bytes for event of type {}",
                                 BBDO_HEADER_SIZE + packet_size, event_id);
         } else {
-          log_v2::bbdo()->error("unknown event type {} event cannot be decoded",
+          log_v2::bbdo()->warn("unknown event type {} event cannot be decoded",
                                 event_id);
-          log_v2::bbdo()->debug("discarded {} bytes",
+          log_v2::bbdo()->trace("discarded {} bytes",
                                 BBDO_HEADER_SIZE + packet_size);
         }
         return true;


### PR DESCRIPTION
## Description

If a broker receives bbdo message it cannot unserialize because of a missing    
module, it must be able to acknowledge it. Otherwise, this message is kept      
in retention by the peer and this can lead cbd instances to get stuck.

REFS: MON-11162

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)
