### PR TITLE
fix(bam): bad initialization of ba in best status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 Waiting longer for conflict manager to be connected
 
+*bam*
+
+A ba configured with best status was initialized in state OK. And when KPI were
+added, there status was always worst than OK (best case was OK). So even if all
+the kpi were in critical, the state appeared as OK.
+
 ## 20.10.9
 
 Update the headers.

--- a/bam/src/ba.cc
+++ b/bam/src/ba.cc
@@ -75,8 +75,12 @@ static bool _every_kpi_in_dt(std::unordered_map<kpi*, bam::ba::impact_info>& imp
  */
 ba::ba(bool generate_virtual_status)
     : _state_source(configuration::ba::state_source_impact),
-      _computed_soft_state(ba::state::state_ok),
-      _computed_hard_state(ba::state::state_ok),
+      _computed_soft_state(source == configuration::ba::state_source_best
+                               ? ba::state::state_critical
+                               : ba::state::state_ok),
+      _computed_hard_state(source == configuration::ba::state_source_best
+                               ? ba::state::state_critical
+                               : ba::state::state_ok),
       _num_soft_critical_childs{0.f},
       _num_hard_critical_childs{0.f},
       _acknowledgement_hard(0.0),
@@ -95,7 +99,7 @@ ba::ba(bool generate_virtual_status)
       _recompute_count(0),
       _service_id(0),
       _valid(true),
-      _dt_behaviour{ configuration::ba::dt_ignore } {}
+      _dt_behaviour{configuration::ba::dt_ignore} {}
 
 /**
  *  Add impact.


### PR DESCRIPTION
## Description

When a ba in best status is initialized, it is always in state OK.

REFS: MON-11430

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
