### PR TITLE
fix(bam): the soft state should be updated too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 Waiting longer for conflict manager to be connected
 
+*bam*
+
+A ba configured with best status was initialized in state OK. And when KPI were
+added, there status was always worst than OK (best case was OK). So even if all
+the kpi were in critical, the state appeared as OK.
+
 ## 21.04.5
 
 Update the headers.

--- a/bam/src/ba.cc
+++ b/bam/src/ba.cc
@@ -72,8 +72,12 @@ ba::ba(uint32_t id,
       _host_id(host_id),
       _service_id(service_id),
       _generate_virtual_status(generate_virtual_status),
-      _computed_soft_state(ba::state::state_ok),
-      _computed_hard_state(ba::state::state_ok),
+      _computed_soft_state(source == configuration::ba::state_source_best
+                               ? ba::state::state_critical
+                               : ba::state::state_ok),
+      _computed_hard_state(source == configuration::ba::state_source_best
+                               ? ba::state::state_critical
+                               : ba::state::state_ok),
       _num_soft_critical_childs{0.f},
       _num_hard_critical_childs{0.f},
       _acknowledgement_hard(0.0),


### PR DESCRIPTION
## Description

bad initialization of ba in best status: they are always in state OK.

REFS: MON-11430

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
