### PR TITLE
fix(mysql_connection): mysql_ping called less often and with a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ A ba configured with best status was initialized in state OK. And when KPI were
 added, there status was always worst than OK (best case was OK). So even if all
 the kpi were in critical, the state appeared as OK.
 
+*mysql_connection*
+
+A timeout is added on mysql\_ping and this function is less called than before.
+
+
 ## 20.10.9
 
 Update the headers.

--- a/core/src/mysql_connection.cc
+++ b/core/src/mysql_connection.cc
@@ -78,6 +78,11 @@ bool mysql_connection::_server_error(int code) const {
 void mysql_connection::_prepare_connection() {
   mysql_set_character_set(_conn, "utf8mb4");
 
+  /* This is to set a timeout for the mysql_ping() function that can hang
+   * sometimes */
+  uint32_t timeout = 5;
+  mysql_optionsv(_conn, MYSQL_OPT_READ_TIMEOUT, (void*)&timeout);
+
   if (_qps > 1)
     mysql_autocommit(_conn, 0);
   else
@@ -628,21 +633,26 @@ void mysql_connection::_run() {
         _local_tasks_count = tasks_list.size();
         assert(_tasks_list.empty());
       } else {
-        _tasks_condition.wait(lock, [this] {
-          return _finish_asked || !_tasks_list.empty();
-        });
+        /* We are waiting for some activity, nothing to do for now it is time
+         * to make some ping */
+        while (!_tasks_condition.wait_for(
+            lock, std::chrono::seconds(30),
+            [this] { return _finish_asked || !_tasks_list.empty(); })) {
+          lock.unlock();
+          if (mysql_ping(_conn)) {
+            if (!_try_to_reconnect())
+              log_v2::sql()->error("SQL: Reconnection failed.");
+          } else
+            log_v2::sql()->trace("SQL: connection always alive");
+          lock.lock();
+        }
+
         if (_tasks_list.empty()) {
           _state = finished;
         }
         continue;
       }
       lock.unlock();
-
-      if (mysql_ping(_conn)) {
-        if (!_try_to_reconnect())
-          log_v2::sql()->error("SQL: Reconnection failed.");
-      } else
-        log_v2::sql()->trace("SQL: connection always alive");
 
       for (auto& task : tasks_list) {
         --_local_tasks_count;


### PR DESCRIPTION
## Description

mysql_ping can hang sometimes. This patch adds a timeout to this function call and also it is called less often.

REFS: MON-11530

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
