### PR TITLE
fix(storage): when cbd is stopped, the conflict_manager must stop...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ add query sql to check metrics to delete metric and file associated.
 
 *storage*
 
-Waiting longer for conflict manager to be connected
+Waiting longer for conflict manager to be connected without blocking if cbd
+is stopped.
 
 *bam*
 

--- a/storage/src/conflict_manager.cc
+++ b/storage/src/conflict_manager.cc
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <cstring>
 
+#include "com/centreon/broker/config/applier/init.hh"
 #include "com/centreon/broker/database/mysql_result.hh"
 #include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/logging/logging.hh"
@@ -129,7 +130,8 @@ bool conflict_manager::init_storage(bool store_in_db,
   for (count = 0; count < 60; count++) {
     /* Let's wait for 60s for the conflict_manager to be initialized */
     if (_init_cv.wait_for(lk, std::chrono::seconds(1), [&] {
-          return _singleton != nullptr || _state == finished;
+          return _singleton != nullptr || _state == finished ||
+                 config::applier::mode == config::applier::finished;
         })) {
       if (_state == finished)
         return false;


### PR DESCRIPTION
## Description

When cbd is stopped, the conflict manager must stop trying to establish connections.

REFS: MON-11553

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
